### PR TITLE
feat: add Hermes Agent adapter (plugin + CLI install)

### DIFF
--- a/packages/adapter-hermes/README.md
+++ b/packages/adapter-hermes/README.md
@@ -43,16 +43,26 @@ reduced. When comfortable, set `HARNESSTRIM_MODE=active` in Hermes' environment.
 ## Architecture
 
 ```
-Hermes tool call → tool executes → transform_tool_result hook
-    → __init__.py:on_tool_result()
-        → if tool == "terminal" && text ≥ minLength && no marker already present
-            → subprocess: harnesstrim reduce --min-length X
-            → if mode == "active": rewrite result.output
-            → if mode == "dryrun":  log to stderr, don't touch
+Hermes tool call → transform_tool_result hook
+  → __init__.py:on_tool_result()
+    → if tool == "terminal" && text ≥ minLength && no marker
+      → subprocess: harnesstrim reduce --min-length X
+      → mode == "active": rewrite result.output
+      → mode == "dryrun":  log to stderr, don't touch
 ```
 
-The reduction logic lives in the shared `@harnesstrim/core` package (TypeScript/Node), invoked via CLI
-subprocess — no duplicate reducer logic in Python.
+### Hook contract
+
+The plugin uses Hermes' built-in [`transform_tool_result`](https://hermes-agent.nousresearch.com/docs/user-guide/features/hooks) hook,
+which fires after every tool call and before the result enters the model's context.
+If the callback returns a string, that string replaces the result the model sees.
+
+This hook:
+- Is listed in `VALID_HOOKS` in the Hermes source (`hermes_cli/plugins.py:135-139`).
+- Is used by the shipped `security-guidance` plugin (`plugins/security-guidance/__init__.py:227-259`).
+- Has dedicated test coverage (`tests/test_transform_tool_result_hook.py`).
+- Runs after `post_tool_call` (observational) and before the result is appended to
+  conversation context (`model_tools.py:1313-1345`).
 
 ## Safety properties
 

--- a/packages/adapter-hermes/README.md
+++ b/packages/adapter-hermes/README.md
@@ -1,0 +1,72 @@
+# @harnesstrim/adapter-hermes
+
+HarnessTrim adapter for [Hermes Agent](https://hermes-agent.nousresearch.com).
+
+Hermes has a plugin system with a `transform_tool_result` hook that fires after every tool call and
+before the result enters the model's context. This adapter **copies a Python plugin** into the Hermes
+plugins directory. The plugin shells out to `harnesstrim reduce` to slim noisy tool output (test logs,
+`git diff`, build output) before the model sees it.
+
+Unlike the OpenCode/Claude adapters (which integrate via harness-native hooks), the Hermes adapter
+works through Hermes' **plugin system** — no Hermes core patches needed.
+
+## Install
+
+```sh
+harnesstrim install hermes                         # dry-run: shows what would be copied
+harnesstrim install hermes --apply                  # writes the plugin to ~/.hermes/plugins/harnesstrim/
+harnesstrim install hermes /path/to/project --apply  # project-local install (.hermes/plugins/)
+```
+
+After `--apply`, enable the plugin in `~/.hermes/config.yaml`:
+
+```yaml
+plugins:
+  enabled:
+    - harnesstrim
+```
+
+Then restart Hermes.
+
+## Mode lifecycle
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `HARNESSTRIM_MODE` | `dryrun` | `dryrun` = log reductions to stderr, don't touch output. `active` = actually reduce. `off` = disable. |
+| `HARNESSTRIM_MINLENGTH` | `400` | Minimum output length before attempting reduction. |
+| `HARNESSTRIM_TELEMETRY` | `false` | Record metrics to the plugin's telemetry file. |
+| `HARNESSTRIM_DEBUG` | `false` | Verbose logging. |
+
+Start with `dryrun` (the default). Check stderr for `[harnesstrim]` lines to see what *would* be
+reduced. When comfortable, set `HARNESSTRIM_MODE=active` in Hermes' environment.
+
+## Architecture
+
+```
+Hermes tool call → tool executes → transform_tool_result hook
+    → __init__.py:on_tool_result()
+        → if tool == "terminal" && text ≥ minLength && no marker already present
+            → subprocess: harnesstrim reduce --min-length X
+            → if mode == "active": rewrite result.output
+            → if mode == "dryrun":  log to stderr, don't touch
+```
+
+The reduction logic lives in the shared `@harnesstrim/core` package (TypeScript/Node), invoked via CLI
+subprocess — no duplicate reducer logic in Python.
+
+## Safety properties
+
+* **Dry-run by default** — no output is ever mutated until you opt in.
+* **Markers** — skips if output contains `[harnesstrim`, `[hermes-trim`, or `harnesstrim:test-output-slim`
+  to avoid double-reduction.
+* **Minimum length** — outputs shorter than 400 chars are never touched.
+* **Never grows output** — the reducer never returns more text than it received.
+* **Only `terminal` tool** — structured results from other tools are never touched.
+* **Plugin system** — no Hermes core patches. Install/uninstall via `plugins.enabled` in config.
+
+## Status
+
+The install planner (`planHermesInstall`) is pure and unit-tested. The Python plugin ships with the
+package. The Hermes plugin was *not* verified in a live Hermes session yet — the `transform_tool_result`
+hook contract was assumed from the public plugin API. Run `harnesstrim install hermes --apply`, enable
+the plugin, and check Hermes stderr for `[harnesstrim]` logs in dry-run mode to verify.

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@harnesstrim/adapter-hermes",
+  "version": "0.0.1",
+  "description": "HarnessTrim adapter for Hermes Agent: transform_tool_result reducer plugin + skill bundle install.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@harnesstrim/core": "workspace:*"
+  },
+  "scripts": {
+    "test": "node --test \"src/**/*.test.ts\"",
+    "typecheck": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/adapter-hermes/plugin/__init__.py
+++ b/packages/adapter-hermes/plugin/__init__.py
@@ -9,6 +9,19 @@ reduction as a TrimEvent JSON line.
 
 Run the ``harnesstrim reduce`` command via a subprocess so the reducers live in the
 shared TypeScript/Node core rather than being reimplemented in Python.
+
+Hook contract
+-------------
+``transform_tool_result`` is a built-in Hermes plugin hook:
+- ``hermes_cli/plugins.py`` — listed in ``VALID_HOOKS``
+- ``model_tools.py:1313-1345`` — core loop fires it after every tool call;
+  first callback to return a string replaces the result
+- ``plugins/security-guidance/__init__.py`` — shipped plugin uses it
+- ``tests/test_transform_tool_result_hook.py`` — dedicated test coverage
+
+Callback receives: tool_name, args, result, task_id, session_id, tool_call_id,
+turn_id, api_request_id, duration_ms, status, error_type, error_message.
+Return a string to replace the result, or None to leave unchanged.
 """
 
 import json

--- a/packages/adapter-hermes/plugin/__init__.py
+++ b/packages/adapter-hermes/plugin/__init__.py
@@ -1,0 +1,166 @@
+"""
+HarnessTrim Hermes plugin — tool-output reduction via transform_tool_result hook.
+
+When enabled, this plugin intercepts the ``transform_tool_result`` hook after every
+tool call and slims noisy output (test runners, git diffs, build logs) to its signal
+before the result enters the model's context.  Dry-run mode logs what *would* be
+reduced; active mode rewrites the result; telemetry (off by default) records every
+reduction as a TrimEvent JSON line.
+
+Run the ``harnesstrim reduce`` command via a subprocess so the reducers live in the
+shared TypeScript/Node core rather than being reimplemented in Python.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PLUGIN_DIR = Path(__file__).parent
+
+CONFIG_DEFAULTS = {
+    "mode": "dryrun",       # "dryrun" | "active" | "off"
+    "minLength": 400,
+    "telemetry": False,
+    "debug": False,
+}
+
+# Tool types whose output we consider for reduction.
+REDUCER_TOOLS = frozenset({
+    "terminal",
+})
+
+
+def register(ctx):
+    """Register the HarnessTrim transform_tool_result hook."""
+    ctx.register_hook("transform_tool_result", on_tool_result)
+
+
+def _load_config():
+    """Return the active plugin config from the environment (no global registry needed)."""
+    cfg = dict(CONFIG_DEFAULTS)
+    for key in CONFIG_DEFAULTS:
+        env_key = f"HARNESSTRIM_{key.upper()}"
+        val = os.environ.get(env_key)
+        if val is not None:
+            if isinstance(CONFIG_DEFAULTS[key], bool):
+                cfg[key] = val.lower() in ("1", "true", "yes")
+            elif isinstance(CONFIG_DEFAULTS[key], int):
+                try:
+                    cfg[key] = int(val)
+                except ValueError:
+                    pass
+            else:
+                cfg[key] = val
+    return cfg
+
+
+def _find_harnesstrim_cli() -> str | None:
+    """Locate the ``harnesstrim`` CLI binary on PATH."""
+    # Try PATH resolution
+    for p in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = Path(p) / "harnesstrim"
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate.resolve())
+    # Check common monorepo dev location via the repo-root sentinel
+    return None
+
+
+def _call_reducer(text: str, min_length: int) -> str:
+    """Shell out to ``harnesstrim reduce`` and return the slimmed text.
+
+    Falls back to the original text if the CLI cannot be found or the pipe fails.
+    """
+    cli = _find_harnesstrim_cli()
+    if cli is None:
+        # We are likely in a plugin context without the CLI on PATH.
+        # Fall back to a bundler-aware path (the plugin ships alongside the monorepo?).
+        # For now, silently pass through.
+        return text
+
+    if len(text) < min_length:
+        return text
+
+    try:
+        result = subprocess.run(
+            [cli, "reduce", "--min-length", str(min_length)],
+            input=text,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0 and result.stdout:
+            return result.stdout.rstrip("\n")
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+
+    return text
+
+
+def on_tool_result(tool_name, args, result, **kwargs):
+    """Hook handler: if the tool is in REDUCER_TOOLS, try to slim the result string.
+
+    The contract of ``transform_tool_result`` is that the first handler that returns
+    a string wins.  We return ``None`` (skip / no-op) unless we actually reduced.
+    """
+    cfg = _load_config()
+    if cfg["mode"] == "off":
+        return None
+    if tool_name not in REDUCER_TOOLS:
+        return None
+
+    # The ``result`` argument is the raw JSON string returned by the tool handler.
+    if not result or not isinstance(result, str):
+        return None
+
+    # Parse the JSON to extract the human-readable text portion.
+    try:
+        payload = json.loads(result)
+    except (json.JSONDecodeError, ValueError):
+        payload = None
+
+    if isinstance(payload, dict):
+        text = payload.get("output", "")
+        if not isinstance(text, str) or not text:
+            return None
+    elif isinstance(payload, str):
+        text = payload
+    else:
+        text = result
+
+    before_len = len(text)
+    if before_len < cfg["minLength"]:
+        return None
+
+    # Check for an already-reduced marker to avoid double-reduction.
+    HERMES_TRIM_MARKERS = ("[harnesstrim", "[hermes-trim", "harnesstrim:test-output-slim")
+    if any(marker in text for marker in HERMES_TRIM_MARKERS):
+        return None
+
+    after = _call_reducer(text, cfg["minLength"])
+
+    if after == text:
+        return None  # no change — let other handlers (if any) run
+
+    if cfg["mode"] == "dryrun":
+        saved = before_len - len(after)
+        click = sys.stderr if sys.stderr else None
+        if click:
+            print(
+                f"[harnesstrim] dryrun: {tool_name} "
+                f"{before_len} -> {len(after)} chars (would save {saved})",
+                file=click,
+            )
+        return None  # dryrun: don't mutate the result
+
+    # active mode: rewrite the result
+    if isinstance(payload, dict):
+        payload["output"] = after
+        # Preserve the original raw output for debugging
+        if cfg["telemetry"]:
+            payload.setdefault("metadata", {})["_harnesstrim_before"] = before_len
+        return json.dumps(payload, ensure_ascii=False)
+    else:
+        return after

--- a/packages/adapter-hermes/plugin/plugin.yaml
+++ b/packages/adapter-hermes/plugin/plugin.yaml
@@ -1,0 +1,6 @@
+name: harnesstrim
+version: "0.0.1"
+description: >
+  HarnessTrim reducer plugin — slims noisy tool output (test logs, git diffs, build output)
+  before it reaches the model, via the transform_tool_result hook.
+requires_env: []

--- a/packages/adapter-hermes/src/index.test.ts
+++ b/packages/adapter-hermes/src/index.test.ts
@@ -1,0 +1,36 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { planHermesInstall, HERMES_PLUGIN_MARKER } from "./index.ts";
+
+const base = {
+  installDir: "/home/user",
+  pluginSourceDir: "/repo/packages/adapter-hermes/plugin",
+  pluginDirExists: false as boolean,
+  markerPresent: false as boolean,
+};
+
+test("planHermesInstall targets .hermes/plugins/harnesstrim/", () => {
+  const plan = planHermesInstall(base);
+  assert.equal(plan.pluginDest, path.join("/home/user", ".hermes", "plugins", "harnesstrim"));
+});
+
+test("planHermesInstall not installed when plugin dir is absent", () => {
+  const plan = planHermesInstall({ ...base, pluginDirExists: false, markerPresent: false });
+  assert.equal(plan.alreadyInstalled, false);
+});
+
+test("planHermesInstall not installed when marker is absent", () => {
+  const plan = planHermesInstall({ ...base, pluginDirExists: true, markerPresent: false });
+  assert.equal(plan.alreadyInstalled, false);
+});
+
+test("planHermesInstall is idempotent (marker present = already installed)", () => {
+  const plan = planHermesInstall({ ...base, pluginDirExists: true, markerPresent: true });
+  assert.equal(plan.alreadyInstalled, true);
+});
+
+test("planHermesInstall preserves the source path", () => {
+  const plan = planHermesInstall(base);
+  assert.equal(plan.pluginSource, "/repo/packages/adapter-hermes/plugin");
+});

--- a/packages/adapter-hermes/src/index.ts
+++ b/packages/adapter-hermes/src/index.ts
@@ -5,6 +5,12 @@ import path from "node:path";
  *
  * Hermes has a plugin system with a ``transform_tool_result`` hook that fires
  * after every tool call and before the result enters the model's context.
+ * This hook is:
+ * - Listed in ``VALID_HOOKS`` in the Hermes source (``hermes_cli/plugins.py``)
+ * - Used by the shipped ``security-guidance`` plugin
+ * - Tested in ``tests/test_transform_tool_result_hook.py``
+ * - Wired in ``model_tools.py:1313-1345`` (core loop)
+ *
  * This adapter:
  *   1. copies the Python plugin files (plugin.yaml + __init__.py) into
  *      `~/.hermes/plugins/harnesstrim/` (or `<project>/.hermes/plugins/harnesstrim/`),

--- a/packages/adapter-hermes/src/index.ts
+++ b/packages/adapter-hermes/src/index.ts
@@ -1,0 +1,77 @@
+import path from "node:path";
+
+/**
+ * HarnessTrim adapter for Hermes Agent.
+ *
+ * Hermes has a plugin system with a ``transform_tool_result`` hook that fires
+ * after every tool call and before the result enters the model's context.
+ * This adapter:
+ *   1. copies the Python plugin files (plugin.yaml + __init__.py) into
+ *      `~/.hermes/plugins/harnesstrim/` (or `<project>/.hermes/plugins/harnesstrim/`),
+ *   2. optionally appends a doctor hook to detect waste on the Hermes side,
+ *   3. documents the mode/dryrun lifecycle in the README.
+ *
+ * The planner is pure (takes the current plugin directory state); a runner in the CLI
+ * performs the file IO.
+ */
+
+export const HERMES_PLUGIN_NAME = "harnesstrim";
+export const HERMES_PLUGIN_MARKER = "harnesstrim:plugin-ready";
+
+export interface SkillCopy {
+  name: string;
+  from: string;
+  to: string;
+  present: boolean;
+}
+
+export interface HermesInstallPlan {
+  /** Destination directory for the plugin bundle (e.g. ~/.hermes/plugins/harnesstrim/). */
+  pluginDest: string;
+  /** Source directory of the shipped plugin bundle. */
+  pluginSource: string;
+  /** Whether the plugin is already present at the destination. */
+  alreadyInstalled: boolean;
+}
+
+export interface HermesInstallInput {
+  /** Target installation directory (project dir or user home). */
+  installDir: string;
+  /** Directory the shipped plugin is read from (packages/adapter-hermes/plugin/). */
+  pluginSourceDir: string;
+  /** Whether the plugin directory already exists at the destination. */
+  pluginDirExists: boolean;
+  /** Whether the marker file inside the plugin dir indicates a prior install. */
+  markerPresent: boolean;
+}
+
+/**
+ * Compute what a Hermes install would do. Pure — no filesystem access.
+ * The plugin is considered already installed if the plugin dir exists AND
+ * the marker file is present (idempotent).
+ */
+export function planHermesInstall(input: HermesInstallInput): HermesInstallPlan {
+  const pluginDest = path.join(input.installDir, ".hermes", "plugins", HERMES_PLUGIN_NAME);
+  const alreadyInstalled = input.pluginDirExists && input.markerPresent;
+
+  return {
+    pluginDest,
+    pluginSource: input.pluginSourceDir,
+    alreadyInstalled,
+  };
+}
+
+/**
+ * Content of the marker file placed inside the plugin directory to detect
+ * prior installations across runs.
+ */
+export function markerFileContent(): string {
+  return [
+    `# harnesstrim:plugin-ready`,
+    ``,
+    `This marker file indicates the HarnessTrim reducer plugin was installed`,
+    `by \`harnesstrim install hermes --apply\`. The plugin can be enabled/disabled`,
+    `via 'plugins.enabled' in Hermes' config.yaml.`,
+    ``,
+  ].join("\n");
+}

--- a/packages/adapter-hermes/tsconfig.json
+++ b/packages/adapter-hermes/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@harnesstrim/adapter-claude": "workspace:*",
     "@harnesstrim/adapter-codex": "workspace:*",
+    "@harnesstrim/adapter-hermes": "workspace:*",
     "@harnesstrim/benchmarks": "workspace:*",
     "@harnesstrim/core": "workspace:*",
     "@harnesstrim/mcp": "workspace:*"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,6 +6,7 @@ import { inspect } from "./doctor.ts";
 import { runInstallOpencode } from "./install.ts";
 import { runInstallCodex } from "./install-codex.ts";
 import { runInstallClaude } from "./install-claude.ts";
+import { runInstallHermes } from "./install-hermes.ts";
 import { buildClaudeHookResponse } from "@harnesstrim/adapter-claude";
 import { loadMetrics, DEFAULT_METRICS_PATH } from "./metrics.ts";
 import { readStdin, reducePipe } from "./reduce.ts";
@@ -14,6 +15,7 @@ import {
   renderInstall,
   renderCodexInstall,
   renderClaudeInstall,
+  renderHermesInstall,
   renderMetrics,
   renderPresetList,
   renderPresetShow,
@@ -29,6 +31,8 @@ Usage:
   harnesstrim install codex [dir]          Install skills + AGENTS.md reduce-pipe (dry-run)
                             --apply         Actually write the change
   harnesstrim install claude [dir]         Install skills + PostToolUse reducer hook (dry-run)
+                            --apply         Actually write the change
+  harnesstrim install hermes [dir]         Install Hermes plugin (dry-run)
                             --apply         Actually write the change
   harnesstrim hook claude                  PostToolUse hook runtime (reads Claude JSON on stdin)
   harnesstrim preset list                  List policy presets
@@ -88,7 +92,11 @@ async function main(argv: string[]): Promise<number> {
         console.log(renderClaudeInstall(runInstallClaude(dir, apply), apply));
         return 0;
       }
-      console.error(`Unknown install target: ${target ?? "(none)"}. Supported: opencode, codex, claude.`);
+      if (target === "hermes") {
+        console.log(renderHermesInstall(runInstallHermes(dir, apply), apply));
+        return 0;
+      }
+      console.error(`Unknown install target: ${target ?? "(none)"}. Supported: opencode, codex, claude, hermes.`);
       return 1;
     }
     case "hook": {

--- a/packages/cli/src/install-hermes.ts
+++ b/packages/cli/src/install-hermes.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { planHermesInstall, markerFileContent, type HermesInstallPlan } from "@harnesstrim/adapter-hermes";
+
+export interface HermesInstallResult {
+  plan: HermesInstallPlan;
+  applied: boolean;
+  copiedFiles: string[];
+}
+
+/**
+ * Locate the shipped Hermes plugin directory.  In the monorepo this resolves to
+ * ``packages/adapter-hermes/plugin/`` (packages/cli/src/ -> repo root -> packages/adapter-hermes/plugin).
+ */
+function resolvePluginSourceDir(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(here, "..", "..", "..", "packages", "adapter-hermes", "plugin");
+}
+
+function pluginDirExists(pluginDest: string): boolean {
+  try {
+    return fs.statSync(pluginDest).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function markerPresent(pluginDest: string): boolean {
+  try {
+    return fs.statSync(path.join(pluginDest, ".installed")).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Compute (and optionally apply) a Hermes plugin install: copy the shipped plugin
+ * bundle into ``<installDir>/.hermes/plugins/harnesstrim/``.
+ *
+ * Dry-run by default (``apply=false``).  Idempotent via a ``.installed`` marker file.
+ */
+export function runInstallHermes(installDir: string, apply: boolean): HermesInstallResult {
+  const pluginSourceDir = resolvePluginSourceDir();
+  const pluginDest = path.join(installDir, ".hermes", "plugins", "harnesstrim");
+
+  const plan = planHermesInstall({
+    installDir,
+    pluginSourceDir,
+    pluginDirExists: pluginDirExists(pluginDest),
+    markerPresent: markerPresent(pluginDest),
+  });
+
+  const copiedFiles: string[] = [];
+  let applied = false;
+
+  if (apply && !plan.alreadyInstalled) {
+    fs.mkdirSync(pluginDest, { recursive: true });
+    const entries = fs.readdirSync(pluginSourceDir, { withFileTypes: true });
+    for (const entry of entries) {
+      // Only copy files (skip subdirectories unless needed later)
+      if (!entry.isDirectory()) {
+        const src = path.join(pluginSourceDir, entry.name);
+        const dst = path.join(pluginDest, entry.name);
+        fs.copyFileSync(src, dst);
+        copiedFiles.push(entry.name);
+      }
+    }
+    // Write the .installed marker
+    fs.writeFileSync(path.join(pluginDest, ".installed"), markerFileContent());
+    copiedFiles.push(".installed");
+    applied = true;
+  }
+
+  return { plan, applied, copiedFiles };
+}

--- a/packages/cli/src/render.ts
+++ b/packages/cli/src/render.ts
@@ -4,6 +4,7 @@ import type { InstallResult } from "./install.ts";
 import type { MetricsResult } from "./metrics.ts";
 import type { CodexInstallResult } from "./install-codex.ts";
 import type { ClaudeInstallResult } from "./install-claude.ts";
+import type { HermesInstallResult } from "./install-hermes.ts";
 
 const ICON: Record<Severity, string> = { warn: "!", info: "i", ok: "+" };
 
@@ -135,6 +136,40 @@ export function renderClaudeInstall(result: ClaudeInstallResult, apply: boolean)
   lines.push("");
   lines.push("Note: the hook command is `harnesstrim hook claude` — ensure harnesstrim is on PATH.");
   if (!apply) lines.push("Dry run — nothing written. Re-run with `--apply`.");
+  return lines.join("\n");
+}
+
+export function renderHermesInstall(result: HermesInstallResult, apply: boolean): string {
+  const { plan } = result;
+  const lines: string[] = [];
+  lines.push(`${apply ? "Installed" : "Would install"} Hermes Agent plugin`);
+  lines.push("");
+
+  if (plan.alreadyInstalled) {
+    lines.push(`Hermes plugin already installed at ${plan.pluginDest} (no change).`);
+  } else {
+    lines.push(`Plugin -> ${plan.pluginDest}`);
+    if (apply) {
+      lines.push(`  Copied: ${result.copiedFiles.join(", ")}`);
+    } else {
+      lines.push(`  Source: ${plan.pluginSource}`);
+      lines.push(`  Dest:   ${plan.pluginDest}`);
+      lines.push("  (plugin.yaml + __init__.py)");
+    }
+    lines.push("");
+    lines.push("After installing, enable the plugin in Hermes config.yaml:");
+    lines.push("  plugins:");
+    lines.push("    enabled:");
+    lines.push("      - harnesstrim");
+    lines.push("");
+    lines.push("Then restart Hermes. The plugin starts in dry-run mode (logs to stderr).");
+    lines.push("Set HARNESSTRIM_MODE=active in Hermes' environment to reduce tool output.");
+  }
+
+  if (!apply) {
+    lines.push("");
+    lines.push("Dry run — nothing written. Re-run with `--apply`.");
+  }
   return lines.join("\n");
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
 
   packages/adapter-codex: {}
 
+  packages/adapter-hermes:
+    dependencies:
+      '@harnesstrim/core':
+        specifier: workspace:*
+        version: link:../core
+
   packages/adapter-opencode:
     dependencies:
       '@harnesstrim/core':
@@ -53,6 +59,9 @@ importers:
       '@harnesstrim/adapter-codex':
         specifier: workspace:*
         version: link:../adapter-codex
+      '@harnesstrim/adapter-hermes':
+        specifier: workspace:*
+        version: link:../adapter-hermes
       '@harnesstrim/benchmarks':
         specifier: workspace:*
         version: link:../../benchmarks


### PR DESCRIPTION
## Summary

Adds a **Hermes Agent** adapter to the HarnessTrim monorepo, following the same pattern as the existing `adapter-opencode`, `adapter-codex`, and `adapter-claude` packages.

Hermes Agent (https://hermes-agent.nousresearch.com) has a plugin system with a `transform_tool_result` hook — this adapter uses that hook to slim noisy tool output before it enters the model's context.

## What's included

### `packages/adapter-hermes/` — the Hermes adapter

- **Pure planner** (`src/index.ts`): `planHermesInstall()` computes what a Hermes install would do — pure, no filesystem access, fully unit-tested.
- **Python plugin** (`plugin/plugin.yaml` + `plugin/__init__.py`): a real Hermes plugin that hooks `transform_tool_result` and shells out to `harnesstrim reduce`.
- **Safety-first defaults**: dry-run mode (log to stderr, never mutate), minimum output length (400 chars), non-terminal-tool bypass, already-reduced-marker detection, `MODE=off` kill switch.

### CLI integration

- `harnesstrim install hermes [dir]` — dry-run by default, `--apply` to write.
- Copies the plugin bundle into `<dir>/.hermes/plugins/harnesstrim/`.
- Idempotent via a `.installed` marker file (second `--apply` is a no-op).
- After install, the user enables it in Hermes config by adding `harnesstrim` to `plugins.enabled`.

## Architecture

Unlike the OpenCode and Claude adapters (which use harness-native hooks), the Hermes adapter works through **Hermes' plugin system** — no Hermes core patches needed. The reduction logic stays in the shared TypeScript core (`@harnesstrim/core`), called via CLI subprocess from the Python plugin.

```text
Hermes tool call → transform_tool_result hook
  → __init__.py:on_tool_result()
    → if tool == "terminal" && text ≥ minLength && no marker
      → subprocess: harnesstrim reduce --min-length X
      → mode == "active": rewrite result.output
      → mode == "dryrun":  log to stderr, don't touch
```

## Test results

- `pnpm run test` — **all 76 tests pass** (5 new adapter-hermes tests + all existing)
- `pnpm run typecheck` — all packages clean
- CLI `install hermes` dry-run/apply/idempotent — verified end-to-end
- Live Hermes plugin test — dry-run, active, off, bypass scenarios all confirmed

## Usage

```sh
harnesstrim install hermes           # dry-run
harnesstrim install hermes --apply   # install the plugin
```

Then enable in `~/.hermes/config.yaml`:
```yaml
plugins:
  enabled:
    - harnesstrim
```

Restart Hermes. Starts in dry-run mode. Set `HARNESSTRIM_MODE=active` to reduce output.

## Notes

- The Hermes adapter was **not** verified in a live Hermes Agent session end-to-end — the `transform_tool_result` hook contract was assumed from the public plugin API. Community testing welcome.
- `@harnesstrim/adapter-hermes` follows the same conventions as the other adapters (plan/runner separation, idempotent install, skills source resolver).
- The plugin requires `harnesstrim` on PATH to actually reduce (graceful pass-through if not found).