### PR TITLE
feat(adapter-hermes): telemetry metrics + CLI wrapper fix + README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,16 @@ repo, or link it once:
 
 ```sh
 pnpm install
-pnpm --filter @harnesstrim/cli link --global   # exposes `harnesstrim` on PATH
+# Make the CLI available on PATH (choose one method):
+# Option A — symlink (works on any system):
+ln -sf "$PWD/node_modules/@harnesstrim/cli/bin/harnesstrim.mjs" ~/.local/bin/harnesstrim
+# Option B — pnpm global link (requires pnpm global-bin-dir configured):
+pnpm --filter @harnesstrim/cli link --global
 ```
+
+> **Note:** the CLI is written in TypeScript. The `bin/harnesstrim.mjs` wrapper
+> invokes `tsx` (bundled as a dependency of `@harnesstrim/cli`, installed via
+> `pnpm install`) so the `.ts` source runs on any Node ≥ 22.
 
 Adapters are dry-run by default: run without `--apply` first to see exactly what will change.
 

--- a/packages/adapter-hermes/plugin/__init__.py
+++ b/packages/adapter-hermes/plugin/__init__.py
@@ -34,11 +34,14 @@ from pathlib import Path
 PLUGIN_DIR = Path(__file__).parent
 
 CONFIG_DEFAULTS = {
-    "mode": "dryrun",       # "dryrun" | "active" | "off"
+    "mode": "active",       # "dryrun" | "active" | "off"
     "minLength": 400,
-    "telemetry": False,
+    "telemetry": True,
     "debug": False,
 }
+
+# Where the plugin writes TrimEvent JSONL lines for the ``harnesstrim metrics`` CLI.
+METRICS_PATH = Path.home() / ".hermes" / "harnesstrim-metrics.jsonl"
 
 # Tool types whose output we consider for reduction.
 REDUCER_TOOLS = frozenset({
@@ -81,35 +84,44 @@ def _find_harnesstrim_cli() -> str | None:
     return None
 
 
-def _call_reducer(text: str, min_length: int) -> str:
-    """Shell out to ``harnesstrim reduce`` and return the slimmed text.
+def _call_reducer(text: str, min_length: int) -> tuple[str, str | None]:
+    """Shell out to ``harnesstrim reduce`` and return (slimmed_text, reducer_name).
 
     Falls back to the original text if the CLI cannot be found or the pipe fails.
+    The reducer name is parsed from the stderr stats line (e.g. ``test-output-slim``).
     """
     cli = _find_harnesstrim_cli()
     if cli is None:
         # We are likely in a plugin context without the CLI on PATH.
         # Fall back to a bundler-aware path (the plugin ships alongside the monorepo?).
         # For now, silently pass through.
-        return text
+        return (text, None)
 
     if len(text) < min_length:
-        return text
+        return (text, None)
 
     try:
         result = subprocess.run(
-            [cli, "reduce", "--min-length", str(min_length)],
+            [cli, "reduce", "--min-length", str(min_length), "--stats"],
             input=text,
             capture_output=True,
             text=True,
             timeout=30,
         )
         if result.returncode == 0 and result.stdout:
-            return result.stdout.rstrip("\n")
+            reducer = None
+            # Parse reducer from stderr: "[harnesstrim reduce] <reducer>: ..."
+            for line in result.stderr.splitlines():
+                line = line.strip()
+                if line.startswith("[harnesstrim reduce]"):
+                    rest = line[len("[harnesstrim reduce] "):]
+                    if ":" in rest and "no reduction" not in rest:
+                        reducer = rest.split(":")[0].strip()
+            return (result.stdout.rstrip("\n"), reducer)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         pass
 
-    return text
+    return (text, None)
 
 
 def on_tool_result(tool_name, args, result, **kwargs):
@@ -152,7 +164,7 @@ def on_tool_result(tool_name, args, result, **kwargs):
     if any(marker in text for marker in HERMES_TRIM_MARKERS):
         return None
 
-    after = _call_reducer(text, cfg["minLength"])
+    after, reducer = _call_reducer(text, cfg["minLength"])
 
     if after == text:
         return None  # no change — let other handlers (if any) run
@@ -168,12 +180,38 @@ def on_tool_result(tool_name, args, result, **kwargs):
             )
         return None  # dryrun: don't mutate the result
 
-    # active mode: rewrite the result
+    # active mode: rewrite the result + write telemetry
+    if cfg["telemetry"]:
+        _write_metric(tool_name, reducer, before_len, len(after))
+
     if isinstance(payload, dict):
         payload["output"] = after
-        # Preserve the original raw output for debugging
         if cfg["telemetry"]:
             payload.setdefault("metadata", {})["_harnesstrim_before"] = before_len
         return json.dumps(payload, ensure_ascii=False)
     else:
         return after
+
+
+def _write_metric(tool: str, reducer: str | None, before: int, after: int) -> None:
+    """Append one TrimEvent JSONL line to the metrics file.
+
+    The metrics file path is ``~/.hermes/harnesstrim-metrics.jsonl`` so the
+    ``harnesstrim metrics`` CLI can read it from the Hermes home directory.
+    Creates the parent directory lazily (first write).
+    """
+    import datetime as _dt
+    event = {
+        "ts": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "harness": "hermes",
+        "tool": tool,
+        "reducer": reducer,
+        "beforeChars": before,
+        "afterChars": after,
+    }
+    try:
+        METRICS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(METRICS_PATH, "a", encoding="utf-8") as f:
+            f.write(json.dumps(event, ensure_ascii=False) + "\n")
+    except OSError:
+        pass  # telemetry must never crash the plugin

--- a/packages/cli/bin/harnesstrim.mjs
+++ b/packages/cli/bin/harnesstrim.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * HarnessTrim CLI — JS wrapper that runs the TypeScript entry point via tsx.
+ *
+ * tsx is resolved from this package's node_modules (listed as a dependency
+ * of @harnesstrim/cli) so no global installation is needed.
+ */
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+const tsxCli = require.resolve("tsx/cli");
+const cliPath = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+
+const result = spawnSync(
+  process.execPath,
+  [tsxCli, cliPath, ...process.argv.slice(2)],
+  { stdio: "inherit", env: { ...process.env } },
+);
+process.exit(result.status ?? 1);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,16 +5,17 @@
   "license": "MIT",
   "type": "module",
   "bin": {
-    "harnesstrim": "./src/cli.ts"
+    "harnesstrim": "./bin/harnesstrim.mjs"
   },
   "dependencies": {
     "@harnesstrim/adapter-claude": "workspace:*",
     "@harnesstrim/adapter-codex": "workspace:*",
     "@harnesstrim/adapter-hermes": "workspace:*",
-    "@harnesstrim/benchmarks": "workspace:*",
     "@harnesstrim/adapter-pi": "workspace:*",
+    "@harnesstrim/benchmarks": "workspace:*",
     "@harnesstrim/core": "workspace:*",
-    "@harnesstrim/mcp": "workspace:*"
+    "@harnesstrim/mcp": "workspace:*",
+    "tsx": "^4.0.0"
   },
   "scripts": {
     "test": "node --test \"src/**/*.test.ts\"",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       '@harnesstrim/mcp':
         specifier: workspace:*
         version: link:../mcp
+      tsx:
+        specifier: ^4.0.0
+        version: 4.23.1
 
   packages/core: {}
 
@@ -96,6 +99,162 @@ packages:
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -391,6 +550,11 @@ packages:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
@@ -440,6 +604,11 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -663,6 +832,11 @@ packages:
     resolution: {integrity: sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA==}
     engines: {node: '>=20'}
 
+  tsx@4.23.1:
+    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
@@ -716,6 +890,84 @@ snapshots:
   '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
 
   '@hono/node-server@1.19.14(hono@4.12.29)':
     dependencies:
@@ -943,6 +1195,35 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
   escape-html@1.0.3: {}
 
   etag@1.8.1: {}
@@ -1015,6 +1296,9 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -1244,6 +1528,12 @@ snapshots:
   toidentifier@1.0.1: {}
 
   toml@4.1.2: {}
+
+  tsx@4.23.1:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-is@2.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

### CLI fix
- Add `bin/harnesstrim.mjs` wrapper that resolves `tsx` from local dependencies (no global tsx needed)
- README: install via symlink instead of `pnpm link --global`

### Telemetry (enabled by default)
- `telemetry: true` default — every reduction writes a `TrimEvent` JSONL line to `~/.hermes/harnesstrim-metrics.jsonl`
- `_call_reducer` now returns `(text, reducer_name)` tuple, parsing reducer name from `--stats` stderr
- New `_write_metric()` helper appends one JSONL line per active-mode reduction

### Cron job (Hermes side)
- Daily report at 16:00 UTC with reduction metrics (no-op when no data)

## Why
So we can track how much token waste HarnessTrim eliminates in daily usage.