### PR TITLE
Add optional Codex output reduction hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ pnpm exec harnesstrim install hermes --apply      # Hermes Agent plugin
 pnpm exec harnesstrim install opencode --apply    # OpenCode runtime plugin
 pnpm exec harnesstrim install claude --apply      # Claude Code PostToolUse hook
 pnpm exec harnesstrim install codex --apply       # Codex skill pack + AGENTS.md instruction
+pnpm exec harnesstrim install codex --hook --apply # optional experimental Bash PostToolUse hook
 pnpm exec harnesstrim install pi --apply          # Pi extension
 ```
 
@@ -289,6 +290,7 @@ pnpm exec harnesstrim doctor [dir]            # diagnose token-waste signals in 
 pnpm exec harnesstrim install opencode [dir]  # OpenCode plugin -> opencode.json (dry-run)
 pnpm exec harnesstrim install opencode --preset lean-debug --apply
 pnpm exec harnesstrim install codex [dir]     # Codex: skills + AGENTS.md reduce-pipe (dry-run)
+                                             # add --hook for experimental automatic Bash reduction
 pnpm exec harnesstrim install claude [dir]    # Claude Code: skills + PostToolUse hook (dry-run)
 pnpm exec harnesstrim install hermes [dir]    # Hermes Agent: transform_tool_result plugin (dry-run)
 pnpm exec harnesstrim install pi [dir]        # Pi: tool_result extension (dry-run)
@@ -340,7 +342,7 @@ harness. "dry-run mode" here means the adapter logs what it *would* slim without
 | --- | --- | --- | --- |
 | OpenCode | **Yes** — plugin `mode` defaults to `active` | already permanent in `opencode.json`; set `"mode": "dryrun"` there to only preview | off; set plugin option `"telemetry": true` (+ optional `telemetryPath`), read with `harnesstrim metrics <path>` |
 | Claude Code | **Yes** — the `PostToolUse` hook reduces once loaded (no dry-run mode) | permanent once in `.claude/settings.json` | none (the hook does not emit metrics) |
-| Codex | No automatic reduction — the model pipes through `harnesstrim reduce` or calls the MCP `reduce` tool | permanent (the `AGENTS.md` instruction / MCP registration persists) | via the MCP/pipe path, not an adapter emitter |
+| Codex | Default: model pipes through `harnesstrim reduce` or calls MCP `reduce`. Experimental `--hook`: automatically reduces supported Bash results. | `AGENTS.md` / MCP, or `--hook` in trusted projects | `--hook` writes `.harnesstrim/metrics.jsonl`; MCP/pipe telemetry is manual |
 | Hermes | **No** — starts in `dryrun` | set `HARNESSTRIM_MODE=active` in Hermes' persistent environment | off; set `HARNESSTRIM_TELEMETRY=1`, then run `harnesstrim metrics` |
 | Pi | **No** — starts in `dryrun` | set `HARNESSTRIM_MODE=active` **persistently** in Pi's environment | none yet (the extension only reduces) |
 
@@ -373,6 +375,18 @@ must be on PATH. For a first-class, native tool instead of a shell pipe, registe
 ```sh
 codex mcp add harnesstrim -- harnesstrim mcp
 ```
+
+For experimental automatic reduction of simple Bash results, add the opt-in hook:
+
+```sh
+harnesstrim install codex /path/to/project --hook --apply
+```
+
+It writes a project-local `.codex/hooks.json` entry for `PostToolUse` (Bash only) and
+records reductions in `.harnesstrim/metrics.jsonl`. Codex currently lacks a supported
+in-place tool-output replacement API, so the hook uses Codex's documented
+block-and-replace fallback. It is deliberately opt-in: it does not intercept every shell
+execution or non-shell tools, and you must review/trust the hook in Codex before it runs.
 
 Details: [`packages/adapter-codex`](packages/adapter-codex/README.md),
 [`packages/mcp`](packages/mcp/README.md).

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ pnpm exec harnesstrim install opencode --apply    # OpenCode runtime plugin
 pnpm exec harnesstrim install claude --apply      # Claude Code PostToolUse hook
 pnpm exec harnesstrim install codex --apply       # Codex skill pack + AGENTS.md instruction
 pnpm exec harnesstrim install codex --hook --apply # optional experimental Bash PostToolUse hook
+pnpm exec harnesstrim install codex --hook --global --apply # enable the hook for trusted projects
 pnpm exec harnesstrim install pi --apply          # Pi extension
 ```
 
@@ -291,6 +292,7 @@ pnpm exec harnesstrim install opencode [dir]  # OpenCode plugin -> opencode.json
 pnpm exec harnesstrim install opencode --preset lean-debug --apply
 pnpm exec harnesstrim install codex [dir]     # Codex: skills + AGENTS.md reduce-pipe (dry-run)
                                              # add --hook for experimental automatic Bash reduction
+                                             # add --hook --global to install it once in ~/.codex
 pnpm exec harnesstrim install claude [dir]    # Claude Code: skills + PostToolUse hook (dry-run)
 pnpm exec harnesstrim install hermes [dir]    # Hermes Agent: transform_tool_result plugin (dry-run)
 pnpm exec harnesstrim install pi [dir]        # Pi: tool_result extension (dry-run)
@@ -342,7 +344,7 @@ harness. "dry-run mode" here means the adapter logs what it *would* slim without
 | --- | --- | --- | --- |
 | OpenCode | **Yes** — plugin `mode` defaults to `active` | already permanent in `opencode.json`; set `"mode": "dryrun"` there to only preview | off; set plugin option `"telemetry": true` (+ optional `telemetryPath`), read with `harnesstrim metrics <path>` |
 | Claude Code | **Yes** — the `PostToolUse` hook reduces once loaded (no dry-run mode) | permanent once in `.claude/settings.json` | none (the hook does not emit metrics) |
-| Codex | Default: model pipes through `harnesstrim reduce` or calls MCP `reduce`. Experimental `--hook`: automatically reduces supported Bash results. | `AGENTS.md` / MCP, or `--hook` in trusted projects | `--hook` writes `.harnesstrim/metrics.jsonl`; MCP/pipe telemetry is manual |
+| Codex | Default: model pipes through `harnesstrim reduce` or calls MCP `reduce`. Experimental `--hook`: automatically reduces supported Bash results. | `AGENTS.md` / MCP, project `--hook`, or global `--hook --global` for trusted projects | hook telemetry is written per project to `.harnesstrim/metrics.jsonl`; MCP/pipe telemetry is manual |
 | Hermes | **No** — starts in `dryrun` | set `HARNESSTRIM_MODE=active` in Hermes' persistent environment | off; set `HARNESSTRIM_TELEMETRY=1`, then run `harnesstrim metrics` |
 | Pi | **No** — starts in `dryrun` | set `HARNESSTRIM_MODE=active` **persistently** in Pi's environment | none yet (the extension only reduces) |
 
@@ -387,6 +389,17 @@ records reductions in `.harnesstrim/metrics.jsonl`. Codex currently lacks a supp
 in-place tool-output replacement API, so the hook uses Codex's documented
 block-and-replace fallback. It is deliberately opt-in: it does not intercept every shell
 execution or non-shell tools, and you must review/trust the hook in Codex before it runs.
+
+To enable the same opt-in hook for every trusted project without copying skills or changing
+any project `AGENTS.md`, install it once in your Codex home:
+
+```sh
+harnesstrim install codex --hook --global --apply
+```
+
+This writes `~/.codex/hooks.json`. Because Codex runs the hook with the session's project
+directory as its working directory, each project's metrics still land in that project's
+`.harnesstrim/metrics.jsonl`.
 
 Details: [`packages/adapter-codex`](packages/adapter-codex/README.md),
 [`packages/mcp`](packages/mcp/README.md).

--- a/packages/adapter-codex/README.md
+++ b/packages/adapter-codex/README.md
@@ -2,19 +2,25 @@
 
 HarnessTrim adapter for [Codex](https://developers.openai.com/codex).
 
-Codex has no tool-output hook like OpenCode, so this adapter integrates through Codex's native
-surfaces — the Agent Skills standard and the `AGENTS.md` instruction file:
+Codex has no supported in-place tool-output transform like OpenCode, so the stable adapter
+integrates through Codex's native surfaces — the Agent Skills standard and the `AGENTS.md`
+instruction file:
 
 1. **Skill bundle** — copies the portable skills into `<project>/.codex/skills`.
 2. **Reduce-pipe instruction** — appends an `AGENTS.md` section telling the agent to pipe noisy
    command output through `harnesstrim reduce` (deterministic, RTK-style), so only signal enters
    context.
 
+An experimental opt-in `PostToolUse` hook is also available for automatic reduction of simple
+Bash results. It uses Codex's block-and-replace fallback because Codex does not yet expose a
+supported in-place output replacement field.
+
 ## Install
 
 ```sh
 harnesstrim install codex            # dry-run: shows skills to copy + AGENTS.md snippet
 harnesstrim install codex --apply    # writes it
+harnesstrim install codex --hook --apply # also add the experimental Bash hook + telemetry
 ```
 
 Idempotent: skills already present are skipped, and the AGENTS.md instruction is added only once
@@ -31,6 +37,20 @@ git diff | harnesstrim reduce
 
 `harnesstrim reduce` reads stdin, applies the matching reducer, and writes the slimmed output to
 stdout (keeping failures/errors/summaries, dropping passing-test noise and generated-file diffs).
+
+## Experimental automatic Bash reduction
+
+`harnesstrim install codex --hook --apply` writes `.codex/hooks.json` with a `PostToolUse`
+hook matched to `Bash`. The hook reads Codex's `tool_response`, applies `reduceAuto`, and, only
+when it changed the output, returns Codex's documented block-and-replace response containing the
+reduced text. It writes one event per reduction to `.harnesstrim/metrics.jsonl`.
+
+This is opt-in because Codex hooks do not yet offer a stable in-place result transformation:
+
+- only supported/simple Bash calls are intercepted;
+- Web Search and other non-shell tools are not covered;
+- hooks must be reviewed and trusted by Codex before running;
+- malformed or unfamiliar response shapes always pass through unchanged.
 
 ## Status
 

--- a/packages/adapter-codex/README.md
+++ b/packages/adapter-codex/README.md
@@ -21,6 +21,7 @@ supported in-place output replacement field.
 harnesstrim install codex            # dry-run: shows skills to copy + AGENTS.md snippet
 harnesstrim install codex --apply    # writes it
 harnesstrim install codex --hook --apply # also add the experimental Bash hook + telemetry
+harnesstrim install codex --hook --global --apply # install it once for trusted projects
 ```
 
 Idempotent: skills already present are skipped, and the AGENTS.md instruction is added only once
@@ -51,6 +52,11 @@ This is opt-in because Codex hooks do not yet offer a stable in-place result tra
 - Web Search and other non-shell tools are not covered;
 - hooks must be reviewed and trusted by Codex before running;
 - malformed or unfamiliar response shapes always pass through unchanged.
+
+To enable the hook for all trusted projects without copying skills or changing any project
+`AGENTS.md`, use `harnesstrim install codex --hook --global --apply`. This writes the hook to
+`~/.codex/hooks.json`; telemetry remains project-local at `.harnesstrim/metrics.jsonl` because
+Codex runs hooks with the active project's directory as the working directory.
 
 ## Status
 

--- a/packages/adapter-codex/package.json
+++ b/packages/adapter-codex/package.json
@@ -1,12 +1,15 @@
 {
   "name": "@harnesstrim/adapter-codex",
   "version": "0.0.1",
-  "description": "HarnessTrim adapter for Codex: skill bundle + AGENTS.md reduce-pipe instruction.",
+  "description": "HarnessTrim adapter for Codex: skills, AGENTS.md reduction guidance, and an optional PostToolUse hook.",
   "license": "MIT",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "devDependencies": {
+    "@harnesstrim/core": "workspace:*"
   },
   "scripts": {
     "test": "node --test \"src/**/*.test.ts\"",

--- a/packages/adapter-codex/src/hook.test.ts
+++ b/packages/adapter-codex/src/hook.test.ts
@@ -1,0 +1,30 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { reduceCodexPayload } from "./hook.ts";
+
+const noisy =
+  "PASS suite test case number NN ok\n".repeat(40) +
+  "FAIL suite broken case\nExpected: 1\nReceived: 2\nTests: 1 failed, 40 passed, 41 total\n";
+
+test("reduces a Codex PostToolUse Bash response with the documented block-and-replace shape", () => {
+  const { response, event } = reduceCodexPayload(JSON.stringify({ tool_name: "Bash", tool_response: noisy }));
+  const parsed = JSON.parse(response);
+  assert.equal(parsed.decision, "block");
+  assert.match(parsed.reason, /HarnessTrim reduced Bash output \(test-output-slim\)/);
+  assert.match(parsed.reason, /1 failed, 40 passed/);
+  assert.ok(event);
+  assert.equal(event.tool, "Bash");
+  assert.equal(event.reducer, "test-output-slim");
+  assert.ok(event.afterChars < event.beforeChars);
+});
+
+test("reads stdout from object-shaped tool responses", () => {
+  const { response } = reduceCodexPayload(JSON.stringify({ tool_name: "Bash", tool_response: { stdout: noisy } }));
+  assert.notEqual(response, "{}");
+});
+
+test("leaves short, malformed, and unfamiliar payloads untouched", () => {
+  assert.equal(reduceCodexPayload(JSON.stringify({ tool_name: "Bash", tool_response: "all good" })).response, "{}");
+  assert.equal(reduceCodexPayload("{ not json").response, "{}");
+  assert.equal(reduceCodexPayload(JSON.stringify({ tool_name: "Bash", tool_response: { lines: [] } })).response, "{}");
+});

--- a/packages/adapter-codex/src/hook.ts
+++ b/packages/adapter-codex/src/hook.ts
@@ -1,0 +1,66 @@
+import { reduceAuto } from "@harnesstrim/core";
+
+export interface CodexReduction {
+  /** Hook-response JSON to write to stdout (`{}` leaves the result untouched). */
+  response: string;
+  /** Reduction facts for a TrimEvent, or null when nothing was changed. */
+  event: {
+    tool: string;
+    reducer: string | null;
+    beforeChars: number;
+    afterChars: number;
+  } | null;
+}
+
+/**
+ * Reduce a Codex PostToolUse payload. Codex currently has no supported in-place
+ * `updatedToolOutput` field: the documented fallback is to block normal processing
+ * and replace the model-visible result with the hook's reason. Keep this defensive —
+ * an unfamiliar tool-response shape must always pass through untouched.
+ */
+export function reduceCodexPayload(rawJson: string, minLength?: number): CodexReduction {
+  const extracted = extractToolOutput(rawJson);
+  if (extracted === null) return { response: "{}", event: null };
+
+  const result = reduceAuto(extracted.output, minLength);
+  if (!result.changed) return { response: "{}", event: null };
+
+  const response = JSON.stringify({
+    decision: "block",
+    reason: `HarnessTrim reduced ${extracted.toolName} output (${result.reducer}):\n\n${result.output}`,
+  });
+  return {
+    response,
+    event: {
+      tool: extracted.toolName,
+      reducer: result.reducer,
+      beforeChars: extracted.output.length,
+      afterChars: result.output.length,
+    },
+  };
+}
+
+function extractToolOutput(rawJson: string): { toolName: string; output: string } | null {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawJson);
+  } catch {
+    return null;
+  }
+  if (typeof payload !== "object" || payload === null) return null;
+  const p = payload as Record<string, unknown>;
+  const output = extractOutputText(p.tool_response);
+  return output === null
+    ? null
+    : { toolName: typeof p.tool_name === "string" ? p.tool_name : "unknown", output };
+}
+
+function extractOutputText(response: unknown): string | null {
+  if (typeof response === "string") return response;
+  if (typeof response !== "object" || response === null) return null;
+  const r = response as Record<string, unknown>;
+  for (const key of ["stdout", "output", "content"]) {
+    if (typeof r[key] === "string") return r[key] as string;
+  }
+  return null;
+}

--- a/packages/adapter-codex/src/index.test.ts
+++ b/packages/adapter-codex/src/index.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { planCodexInstall, HARNESSTRIM_MARKER } from "./index.ts";
+import { planCodexHookInstall, planCodexInstall, HARNESSTRIM_MARKER } from "./index.ts";
 
 const base = {
   projectDir: "/proj",
@@ -45,4 +45,26 @@ test("instructions action: present (idempotent) when the marker is already there
 test("snippet documents the reduce pipe", () => {
   const plan = planCodexInstall(base);
   assert.match(plan.instructionsSnippet, /harnesstrim reduce/);
+});
+
+test("plans an optional Codex Bash PostToolUse hook with telemetry", () => {
+  const plan = planCodexHookInstall({ projectDir: "/proj", hooksJsonContent: null });
+  assert.equal(plan.action, "create");
+  const post = (plan.nextHooks.hooks as Record<string, unknown>).PostToolUse as Array<Record<string, unknown>>;
+  assert.equal(post[0].matcher, "^Bash$");
+  assert.match(JSON.stringify(post), /harnesstrim hook codex --metrics/);
+});
+
+test("keeps an existing Codex hook idempotent", () => {
+  const hooks = JSON.stringify({
+    hooks: { PostToolUse: [{ matcher: "^Bash$", hooks: [{ type: "command", command: "harnesstrim hook codex --metrics x" }] }] },
+  });
+  assert.equal(planCodexHookInstall({ projectDir: "/proj", hooksJsonContent: hooks }).action, "present");
+});
+
+test("refuses to overwrite malformed hooks.json", () => {
+  assert.throws(
+    () => planCodexHookInstall({ projectDir: "/proj", hooksJsonContent: "{ nope" }),
+    /not valid JSON/
+  );
 });

--- a/packages/adapter-codex/src/index.ts
+++ b/packages/adapter-codex/src/index.ts
@@ -1,11 +1,13 @@
 import path from "node:path";
+export * from "./hook.ts";
 
 /**
  * HarnessTrim adapter for Codex.
  *
- * Codex has no `tool.execute` output hook like OpenCode. Its native surfaces are the
- * Agent Skills standard and the `AGENTS.md` instruction file. So this adapter integrates
- * two ways (matching the source proposal's "regole/istruzioni in Codex" + skills):
+ * Codex has no supported in-place tool-output transform like OpenCode. Its native
+ * surfaces are Agent Skills, `AGENTS.md`, and lifecycle hooks. The stable default
+ * integrates two ways (matching the source proposal's "regole/istruzioni in Codex" +
+ * skills):
  *   1. install the portable skill bundle into a Codex-readable skills directory, and
  *   2. append an AGENTS.md instruction telling the agent to pipe noisy command output
  *      through `harnesstrim reduce` (the deterministic reducer, RTK-style).
@@ -15,6 +17,8 @@ import path from "node:path";
  */
 
 export const HARNESSTRIM_MARKER = "harnesstrim:begin";
+export const CODEX_HOOK_COMMAND = "harnesstrim hook codex --metrics .harnesstrim/metrics.jsonl";
+export const CODEX_HOOK_MATCHER = "^Bash$";
 
 export const REDUCE_INSTRUCTION_SNIPPET = `<!-- ${HARNESSTRIM_MARKER} -->
 ## Token economy (HarnessTrim)
@@ -57,6 +61,76 @@ export interface CodexInstallInput {
   agentsMdContent: string | null;
   /** Skill names already present at the destination. */
   existingSkillNames: string[];
+}
+
+interface HookEntry {
+  matcher?: string;
+  hooks?: Array<{ type?: string; command?: string }>;
+}
+
+export type HooksAction = "create" | "patch" | "present";
+
+export interface CodexHookInstallPlan {
+  hooksFile: string;
+  action: HooksAction;
+  /** Complete hooks.json content to write when the action is create or patch. */
+  nextHooks: Record<string, unknown>;
+}
+
+export interface CodexHookInstallInput {
+  projectDir: string;
+  /** Current .codex/hooks.json content, or null when it does not exist. */
+  hooksJsonContent: string | null;
+}
+
+function hasHarnessTrimHook(document: Record<string, unknown>): boolean {
+  const hooks = document.hooks as Record<string, unknown> | undefined;
+  const post = hooks?.PostToolUse;
+  if (!Array.isArray(post)) return false;
+  return post.some((entry: HookEntry) =>
+    Array.isArray(entry?.hooks) &&
+    entry.hooks.some((hook) => typeof hook?.command === "string" && hook.command.includes("harnesstrim hook codex"))
+  );
+}
+
+/**
+ * Plan the optional Codex PostToolUse integration. It deliberately targets only Bash:
+ * Codex does not currently support a native replacement field for tool output, so the
+ * runtime hook uses its documented block-and-replace fallback for simple shell calls.
+ */
+export function planCodexHookInstall(input: CodexHookInstallInput): CodexHookInstallPlan {
+  let document: Record<string, unknown> = {};
+  let action: HooksAction;
+  if (input.hooksJsonContent === null) {
+    action = "create";
+  } else {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(input.hooksJsonContent);
+    } catch {
+      throw new Error(".codex/hooks.json is not valid JSON; refusing to overwrite it.");
+    }
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error(".codex/hooks.json must contain a JSON object; refusing to overwrite it.");
+    }
+    document = parsed as Record<string, unknown>;
+    action = hasHarnessTrimHook(document) ? "present" : "patch";
+  }
+
+  if (action === "present") {
+    return { hooksFile: path.join(input.projectDir, ".codex", "hooks.json"), action, nextHooks: document };
+  }
+
+  const hooks: Record<string, unknown> = { ...((document.hooks as Record<string, unknown>) ?? {}) };
+  const post: HookEntry[] = Array.isArray(hooks.PostToolUse) ? [...(hooks.PostToolUse as HookEntry[])] : [];
+  post.push({ matcher: CODEX_HOOK_MATCHER, hooks: [{ type: "command", command: CODEX_HOOK_COMMAND }] });
+  hooks.PostToolUse = post;
+
+  return {
+    hooksFile: path.join(input.projectDir, ".codex", "hooks.json"),
+    action,
+    nextHooks: { ...document, hooks },
+  };
 }
 
 /**

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -11,6 +11,7 @@ import { runInstallClaude } from "./install-claude.ts";
 import { runInstallPi } from "./install-pi.ts";
 import { runInstallHermes } from "./install-hermes.ts";
 import { reduceClaudePayload } from "@harnesstrim/adapter-claude";
+import { reduceCodexPayload } from "@harnesstrim/adapter-codex";
 import { loadMetrics, DEFAULT_METRICS_PATH } from "./metrics.ts";
 import { readStdin, reducePipe } from "./reduce.ts";
 import {
@@ -32,8 +33,9 @@ Usage:
   harnesstrim install opencode [dir]       Wire the adapter into opencode.json (dry-run)
                             --apply         Actually write the change
                             --preset <name> Bake a policy preset's adapter config in
-  harnesstrim install codex [dir]          Install skills + AGENTS.md reduce-pipe (dry-run)
+  harnesstrim install codex [dir]          Install skills + AGENTS.md reduction guidance (dry-run)
                             --apply         Actually write the change
+                            --hook          Also install the experimental Bash PostToolUse hook
   harnesstrim install claude [dir]         Install skills + PostToolUse reducer hook (dry-run)
                             --apply         Actually write the change
   harnesstrim install hermes [dir]         Install Hermes plugin (dry-run)
@@ -42,6 +44,8 @@ Usage:
                             --apply         Actually write the change
   harnesstrim hook claude [--metrics <path>]
                                            PostToolUse hook runtime; --metrics records a TrimEvent per reduction
+  harnesstrim hook codex [--metrics <path>]
+                                           PostToolUse runtime for Codex's experimental Bash hook
   harnesstrim preset list                  List policy presets
   harnesstrim preset show <name>           Show a preset in detail
   harnesstrim metrics [path]               Summarize adapter telemetry (JSONL)
@@ -67,6 +71,7 @@ async function main(argv: string[]): Promise<number> {
       "min-length": { type: "string" },
       log: { type: "string" },
       metrics: { type: "string" },
+      hook: { type: "boolean" },
     },
   });
 
@@ -96,7 +101,7 @@ async function main(argv: string[]): Promise<number> {
         return 0;
       }
       if (target === "codex") {
-        console.log(renderCodexInstall(runInstallCodex(dir, apply), apply));
+        console.log(renderCodexInstall(runInstallCodex(dir, apply, values.hook === true), apply));
         return 0;
       }
       if (target === "claude") {
@@ -116,12 +121,12 @@ async function main(argv: string[]): Promise<number> {
     }
     case "hook": {
       const which = rest[0];
-      if (which !== "claude") {
-        console.error(`Unknown hook target: ${which ?? "(none)"}. Supported: claude.`);
+      if (which !== "claude" && which !== "codex") {
+        console.error(`Unknown hook target: ${which ?? "(none)"}. Supported: claude, codex.`);
         return 1;
       }
       const input = await readStdin();
-      const { response, event } = reduceClaudePayload(input);
+      const { response, event } = which === "claude" ? reduceClaudePayload(input) : reduceCodexPayload(input);
       process.stdout.write(response);
       // --metrics <path>: append a TrimEvent per reduction, read by `harnesstrim metrics`.
       if (values.metrics && event) {
@@ -130,7 +135,7 @@ async function main(argv: string[]): Promise<number> {
           fs.mkdirSync(path.dirname(p), { recursive: true });
           fs.appendFileSync(
             p,
-            JSON.stringify({ ts: new Date().toISOString(), harness: "claude", ...event }) + "\n"
+            JSON.stringify({ ts: new Date().toISOString(), harness: which, ...event }) + "\n"
           );
         } catch {
           /* telemetry must never break the hook */

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,7 +6,7 @@ import os from "node:os";
 import { getPreset, listPresets } from "@harnesstrim/core";
 import { inspect } from "./doctor.ts";
 import { runInstallOpencode } from "./install.ts";
-import { runInstallCodex } from "./install-codex.ts";
+import { runInstallCodex, runInstallCodexGlobalHook } from "./install-codex.ts";
 import { runInstallClaude } from "./install-claude.ts";
 import { runInstallPi } from "./install-pi.ts";
 import { runInstallHermes } from "./install-hermes.ts";
@@ -18,6 +18,7 @@ import {
   renderDoctor,
   renderInstall,
   renderCodexInstall,
+  renderCodexGlobalHookInstall,
   renderClaudeInstall,
   renderHermesInstall,
   renderPiInstall,
@@ -36,6 +37,7 @@ Usage:
   harnesstrim install codex [dir]          Install skills + AGENTS.md reduction guidance (dry-run)
                             --apply         Actually write the change
                             --hook          Also install the experimental Bash PostToolUse hook
+                            --global        With --hook, install it once in ~/.codex (no project files)
   harnesstrim install claude [dir]         Install skills + PostToolUse reducer hook (dry-run)
                             --apply         Actually write the change
   harnesstrim install hermes [dir]         Install Hermes plugin (dry-run)
@@ -72,6 +74,7 @@ async function main(argv: string[]): Promise<number> {
       log: { type: "string" },
       metrics: { type: "string" },
       hook: { type: "boolean" },
+      global: { type: "boolean" },
     },
   });
 
@@ -101,6 +104,14 @@ async function main(argv: string[]): Promise<number> {
         return 0;
       }
       if (target === "codex") {
+        if (values.global === true) {
+          if (values.hook !== true) {
+            console.error("`harnesstrim install codex --global` requires `--hook`.");
+            return 1;
+          }
+          console.log(renderCodexGlobalHookInstall(runInstallCodexGlobalHook(path.join(os.homedir(), ".codex"), apply), apply));
+          return 0;
+        }
         console.log(renderCodexInstall(runInstallCodex(dir, apply, values.hook === true), apply));
         return 0;
       }

--- a/packages/cli/src/install-codex.test.ts
+++ b/packages/cli/src/install-codex.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { runInstallCodex } from "./install-codex.ts";
+import { runInstallCodex, runInstallCodexGlobalHook } from "./install-codex.ts";
 
 function tmpProject(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "htrim-codex-"));
@@ -25,4 +25,14 @@ test("Codex hook install is idempotent", () => {
   runInstallCodex(dir, true, true);
   const second = runInstallCodex(dir, true, true);
   assert.equal(second.hookPlan?.action, "present");
+});
+
+test("global hook install writes only the Codex-home hooks file", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "htrim-codex-home-"));
+  const codexHome = path.join(home, ".codex");
+  const result = runInstallCodexGlobalHook(codexHome, true);
+  assert.equal(result.hookPlan.hooksFile, path.join(codexHome, "hooks.json"));
+  assert.equal(fs.existsSync(path.join(home, "AGENTS.md")), false);
+  assert.equal(fs.existsSync(path.join(codexHome, "skills")), false);
+  assert.match(fs.readFileSync(path.join(codexHome, "hooks.json"), "utf8"), /harnesstrim hook codex/);
 });

--- a/packages/cli/src/install-codex.test.ts
+++ b/packages/cli/src/install-codex.test.ts
@@ -1,0 +1,28 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runInstallCodex } from "./install-codex.ts";
+
+function tmpProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "htrim-codex-"));
+}
+
+test("installs the optional Codex hook only when requested", () => {
+  const dir = tmpProject();
+  runInstallCodex(dir, true);
+  assert.equal(fs.existsSync(path.join(dir, ".codex", "hooks.json")), false);
+
+  const result = runInstallCodex(dir, true, true);
+  assert.equal(result.hookPlan?.action, "create");
+  const written = JSON.parse(fs.readFileSync(path.join(dir, ".codex", "hooks.json"), "utf8"));
+  assert.match(JSON.stringify(written), /harnesstrim hook codex --metrics/);
+});
+
+test("Codex hook install is idempotent", () => {
+  const dir = tmpProject();
+  runInstallCodex(dir, true, true);
+  const second = runInstallCodex(dir, true, true);
+  assert.equal(second.hookPlan?.action, "present");
+});

--- a/packages/cli/src/install-codex.ts
+++ b/packages/cli/src/install-codex.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
-import { planCodexInstall, type CodexInstallPlan } from "@harnesstrim/adapter-codex";
+import { planCodexHookInstall, planCodexInstall, type CodexHookInstallPlan, type CodexInstallPlan } from "@harnesstrim/adapter-codex";
 import { resolveSkillsSourceDir, listShippedSkills, existingSkillNames } from "./skills-source.ts";
 
 export interface CodexInstallResult {
   plan: CodexInstallPlan;
+  hookPlan: CodexHookInstallPlan | null;
   applied: boolean;
   copied: string[];
 }
@@ -15,7 +16,7 @@ export interface CodexInstallResult {
  * default; skills already present are skipped and the AGENTS.md snippet is only added
  * once (idempotent via its marker).
  */
-export function runInstallCodex(dir: string, apply: boolean): CodexInstallResult {
+export function runInstallCodex(dir: string, apply: boolean, hook: boolean = false): CodexInstallResult {
   const skillsSourceDir = resolveSkillsSourceDir();
   const skillNames = listShippedSkills(skillsSourceDir);
   const skillsDest = path.join(dir, ".codex", "skills");
@@ -36,6 +37,17 @@ export function runInstallCodex(dir: string, apply: boolean): CodexInstallResult
     existingSkillNames: existingSkillNames(skillsDest),
   });
 
+  const hooksPath = path.join(dir, ".codex", "hooks.json");
+  let hooksJsonContent: string | null = null;
+  if (hook) {
+    try {
+      hooksJsonContent = fs.readFileSync(hooksPath, "utf8");
+    } catch {
+      hooksJsonContent = null;
+    }
+  }
+  const hookPlan = hook ? planCodexHookInstall({ projectDir: dir, hooksJsonContent }) : null;
+
   const copied: string[] = [];
   let applied = false;
   if (apply) {
@@ -49,8 +61,12 @@ export function runInstallCodex(dir: string, apply: boolean): CodexInstallResult
     } else if (plan.instructionsAction === "append") {
       fs.appendFileSync(plan.instructionsFile, "\n\n" + plan.instructionsSnippet + "\n");
     }
+    if (hookPlan && hookPlan.action !== "present") {
+      fs.mkdirSync(path.dirname(hookPlan.hooksFile), { recursive: true });
+      fs.writeFileSync(hookPlan.hooksFile, JSON.stringify(hookPlan.nextHooks, null, 2) + "\n");
+    }
     applied = true;
   }
 
-  return { plan, applied, copied };
+  return { plan, hookPlan, applied, copied };
 }

--- a/packages/cli/src/install-codex.ts
+++ b/packages/cli/src/install-codex.ts
@@ -10,6 +10,26 @@ export interface CodexInstallResult {
   copied: string[];
 }
 
+export interface CodexGlobalHookInstallResult {
+  hookPlan: CodexHookInstallPlan;
+  applied: boolean;
+}
+
+function readHooksJson(hooksPath: string): string | null {
+  try {
+    return fs.readFileSync(hooksPath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function applyHookPlan(plan: CodexHookInstallPlan, apply: boolean): boolean {
+  if (!apply || plan.action === "present") return false;
+  fs.mkdirSync(path.dirname(plan.hooksFile), { recursive: true });
+  fs.writeFileSync(plan.hooksFile, JSON.stringify(plan.nextHooks, null, 2) + "\n");
+  return true;
+}
+
 /**
  * Compute (and optionally apply) a Codex install: copy the shipped skill pack into
  * `<dir>/.codex/skills` and add the reduce-pipe instruction to AGENTS.md. Dry-run by
@@ -38,14 +58,7 @@ export function runInstallCodex(dir: string, apply: boolean, hook: boolean = fal
   });
 
   const hooksPath = path.join(dir, ".codex", "hooks.json");
-  let hooksJsonContent: string | null = null;
-  if (hook) {
-    try {
-      hooksJsonContent = fs.readFileSync(hooksPath, "utf8");
-    } catch {
-      hooksJsonContent = null;
-    }
-  }
+  const hooksJsonContent = hook ? readHooksJson(hooksPath) : null;
   const hookPlan = hook ? planCodexHookInstall({ projectDir: dir, hooksJsonContent }) : null;
 
   const copied: string[] = [];
@@ -61,12 +74,27 @@ export function runInstallCodex(dir: string, apply: boolean, hook: boolean = fal
     } else if (plan.instructionsAction === "append") {
       fs.appendFileSync(plan.instructionsFile, "\n\n" + plan.instructionsSnippet + "\n");
     }
-    if (hookPlan && hookPlan.action !== "present") {
-      fs.mkdirSync(path.dirname(hookPlan.hooksFile), { recursive: true });
-      fs.writeFileSync(hookPlan.hooksFile, JSON.stringify(hookPlan.nextHooks, null, 2) + "\n");
-    }
+    if (hookPlan) applyHookPlan(hookPlan, true);
     applied = true;
   }
 
   return { plan, hookPlan, applied, copied };
+}
+
+/**
+ * Install only the optional hook in Codex's user-level config directory. This avoids
+ * modifying a repository's skills or AGENTS.md while letting trusted projects inherit
+ * the hook. The hook itself writes metrics relative to each session's cwd.
+ */
+export function runInstallCodexGlobalHook(codexHome: string, apply: boolean): CodexGlobalHookInstallResult {
+  const hooksPath = path.join(codexHome, "hooks.json");
+  const hookPlan = planCodexHookInstall({
+    // The planner expects the directory that contains .codex; for a user-level config
+    // the Codex home is itself that directory, so add its parent and use a normal path.
+    projectDir: path.dirname(codexHome),
+    hooksJsonContent: readHooksJson(hooksPath),
+  });
+  // `planCodexHookInstall` produces <projectDir>/.codex/hooks.json. With the parent of
+  // CODEX_HOME above, that is exactly the requested user-level hooks file.
+  return { hookPlan, applied: applyHookPlan(hookPlan, apply) };
 }

--- a/packages/cli/src/render.ts
+++ b/packages/cli/src/render.ts
@@ -102,6 +102,22 @@ export function renderCodexInstall(result: CodexInstallResult, apply: boolean): 
         : `Reduce-pipe instruction ${apply ? "appended" : "would be appended"} to AGENTS.md.`;
   lines.push(instr);
 
+  if (result.hookPlan) {
+    lines.push("");
+    if (result.hookPlan.action === "present") {
+      lines.push(`${result.hookPlan.hooksFile}: HarnessTrim Bash PostToolUse hook already present (no change).`);
+    } else {
+      lines.push(
+        `${result.hookPlan.hooksFile}: experimental Bash PostToolUse hook ${apply ? (result.hookPlan.action === "create" ? "created" : "added") : "would be added"}.`
+      );
+      lines.push("It reduces simple Bash output automatically and records JSONL telemetry in .harnesstrim/metrics.jsonl.");
+      if (!apply) {
+        lines.push("Resulting hooks.json:");
+        lines.push(JSON.stringify(result.hookPlan.nextHooks, null, 2));
+      }
+    }
+  }
+
   if (!apply) {
     lines.push("");
     lines.push("Dry run — nothing written. Re-run with `--apply`.");

--- a/packages/cli/src/render.ts
+++ b/packages/cli/src/render.ts
@@ -2,7 +2,7 @@ import type { Preset } from "@harnesstrim/core";
 import type { DoctorReport, Severity } from "./doctor.ts";
 import type { InstallResult } from "./install.ts";
 import type { MetricsResult } from "./metrics.ts";
-import type { CodexInstallResult } from "./install-codex.ts";
+import type { CodexGlobalHookInstallResult, CodexInstallResult } from "./install-codex.ts";
 import type { ClaudeInstallResult } from "./install-claude.ts";
 import type { PiInstallResult } from "./install-pi.ts";
 import type { HermesInstallResult } from "./install-hermes.ts";
@@ -122,6 +122,22 @@ export function renderCodexInstall(result: CodexInstallResult, apply: boolean): 
     lines.push("");
     lines.push("Dry run — nothing written. Re-run with `--apply`.");
   }
+  return lines.join("\n");
+}
+
+export function renderCodexGlobalHookInstall(result: CodexGlobalHookInstallResult, apply: boolean): string {
+  const lines = [`${apply ? "Installed" : "Would install"} global Codex Bash PostToolUse hook`, ""];
+  if (result.hookPlan.action === "present") {
+    lines.push(`${result.hookPlan.hooksFile}: HarnessTrim hook already present (no change).`);
+  } else {
+    lines.push(`${result.hookPlan.hooksFile}: experimental Bash PostToolUse hook ${apply ? (result.hookPlan.action === "create" ? "created" : "added") : "would be added"}.`);
+    lines.push("It applies in trusted projects and writes telemetry to each project's .harnesstrim/metrics.jsonl.");
+    if (!apply) {
+      lines.push("Resulting hooks.json:");
+      lines.push(JSON.stringify(result.hookPlan.nextHooks, null, 2));
+    }
+  }
+  if (!apply) lines.push("", "Dry run — nothing written. Re-run with `--apply`.");
   return lines.join("\n");
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,11 @@ importers:
         specifier: workspace:*
         version: link:../core
 
-  packages/adapter-codex: {}
+  packages/adapter-codex:
+    devDependencies:
+      '@harnesstrim/core':
+        specifier: workspace:*
+        version: link:../core
 
   packages/adapter-hermes:
     dependencies:


### PR DESCRIPTION
## What changed

- adds `harnesstrim install codex --hook --apply` to install an opt-in Codex `PostToolUse` hook for Bash;
- adds `harnesstrim install codex --hook --global --apply` to enable that hook once from `~/.codex/hooks.json`, without changing project skill packs or `AGENTS.md` files;
- reduces recognized tool responses with the shared reducers and writes `TrimEvent` telemetry to each active project's `.harnesstrim/metrics.jsonl`;
- preserves the existing AGENTS.md + MCP workflow as the stable default;
- documents the experimental behavior and adds installer, reducer, and idempotency tests.

## Why

Codex supports lifecycle hooks, but does not yet expose a supported in-place tool-output transformation. The hook therefore uses the documented block-and-replace fallback only when a response is safely recognized and actually reduced. Unrecognized payloads pass through unchanged.

## Impact

Automatic Codex output reduction is available as an explicit experimental opt-in. It targets supported/simple Bash calls only; non-shell tools remain on the existing instruction/MCP path. The global installer applies only in trusted projects and keeps telemetry per project.

## Validation

- `pnpm run test`
- `pnpm run typecheck`
- `pnpm --filter harnesstrim build`
- `git diff --check`