### PR TITLE
feat(pi): harden structured result installation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -269,7 +269,63 @@ OpenCode plugins run on — this is a deliberate exception, not an inconsistency
 - Real tokenizer choice for Tier A micro-benchmarks (tiktoken vs. Anthropic's tokenizer) — pick per
   target harness's model family, may need both.
 
-## 9. Status log
+## 9. Next-version development plan
+
+### v0.0.6 — installation and adapter hardening
+
+**Goal:** make every published CLI path work from a clean npm installation and close the remaining
+Pi integration uncertainty.
+
+- Ship `--version`/`-v` in the CLI and preserve the bundled-asset resolver for every installer.
+- Validate Pi's structured `tool_result.content` against a live Pi session in both `dryrun` and
+  `active` modes. Confirm that text chunks shrink, non-text chunks are unchanged, failed reductions
+  pass through, and the marker prevents a second reduction.
+- Test both Pi install scopes: project (`<project>/.pi/extensions`) and user
+  (`~/.pi/agent/extensions`), including a second `--apply` that refreshes the bundle.
+- Add a clean-package smoke test that runs each installer from `npm pack` output, so source-layout
+  assumptions cannot regress.
+
+**Exit criteria:** live Pi proof recorded; packaged CLI installation smoke tests pass; every adapter's
+documented install path works from an empty directory.
+
+### v0.1.0 — trustworthy measurement and release automation
+
+**Goal:** graduate from individual reducer wins to evidence-driven defaults.
+
+- Collect opt-in `TrimEvent` telemetry from dogfooding; add reducers only for repeated, measurable
+  noisy-output classes while retaining signal-recall gates.
+- Extend `harnesstrim metrics` with per-harness and per-reducer savings, pass-through rate, and
+  reduction-error counts. Never record tool payloads by default.
+- Add release CI: typecheck, tests, Tier A fidelity benchmark, package smoke test, version/tag
+  validation, npm publish, and generated release notes.
+
+**Exit criteria:** the release pipeline publishes a tested package; reducer additions are supported by
+telemetry and preserve benchmark signal recall.
+
+### v0.2.0 — representative end-to-end evidence
+
+**Goal:** demonstrate savings across real multi-tool coding tasks without degrading task outcomes.
+
+- Expand Tier B to multi-tool tasks, multiple output volumes, and repeated runs on fixed model
+  versions. Report fresh input, cache reads, total billed tokens, success rate, and failure modes
+  separately.
+- Run the same matrix for each harness where deterministic interception is available; describe the
+  Claude/Codex MCP and pipe paths separately from native result hooks.
+- Publish fixtures, raw normalized measurements, and methodology; state confidence bounds and avoid
+  aggregate savings claims that hide cache effects.
+
+**Exit criteria:** reproducible benchmark data shows retained task quality and clearly bounded token
+savings for each supported integration path.
+
+### Deferred unless evidence changes
+
+- Do not add an unrestricted command-execution MCP tool: it would bypass harness sandboxing.
+- Do not rewrite stable instruction prefixes: it risks prompt-cache invalidation.
+- Do not raise the release line beyond `0.x` until package install, live adapter behavior, and
+multi-tool Tier B evidence are all repeatable.
+
+## 10. Status log
+
 
 - **RESUME HERE (next session).** Repo is green: CI passes on Linux/Windows/macOS, 119 tests,
   typecheck clean, bench fidelity OK. **`harnesstrim` is LIVE on npm and verified working end-to-end**

--- a/packages/adapter-pi/README.md
+++ b/packages/adapter-pi/README.md
@@ -5,8 +5,8 @@ HarnessTrim adapter for [Pi](https://pi.dev) (`@earendil-works/pi-coding-agent`)
 Pi loads TypeScript extensions from `~/.pi/agent/extensions/` (global) or `<project>/.pi/extensions/`
 (project-local). Our extension registers a **`tool_result`** handler — Pi's post-tool hook, which
 fires after a tool finishes and before the result reaches the model and lets handlers return a patch
-(`content` / `details` / `isError`). We slim string `content` for noisy output, analogous to
-OpenCode's `tool.execute.after`.
+(`content` / `details` / `isError`). We slim text chunks in the structured `content` array for noisy
+output, analogous to OpenCode's `tool.execute.after`.
 
 The extension is **self-contained**: it shells out to `harnesstrim reduce` (no workspace imports), so
 it loads from any Pi extensions directory. `harnesstrim` must be on PATH; if it's missing the output
@@ -20,7 +20,8 @@ harnesstrim install pi --apply            # -> <project>/.pi/extensions/harnesst
 harnesstrim install pi ~ --apply          # global: ~/.pi/... (pass your home dir)
 ```
 
-Idempotent via a `.installed` marker. Copies the extension bundle; Pi discovers it on next start.
+Each `--apply` refreshes the extension bundle and its `.installed` marker; Pi discovers the result on
+next start.
 
 ## Mode
 

--- a/packages/adapter-pi/extension/harnesstrim.ts
+++ b/packages/adapter-pi/extension/harnesstrim.ts
@@ -2,7 +2,7 @@
 //
 // Pi fires `tool_result` after a tool finishes and before the result reaches the model;
 // handlers chain like middleware and may return a patch ({ content, details, isError }).
-// This extension reduces string `content` for noisy output (test runners, git diffs, ...)
+// This extension reduces text chunks in structured tool results (test runners, git diffs, ...)
 // by shelling out to `harnesstrim reduce`, so it is self-contained (no workspace imports)
 // and loads from `~/.pi/agent/extensions/` or `<project>/.pi/extensions/`.
 //
@@ -12,15 +12,19 @@
 //   HARNESSTRIM_MINLENGTH=<chars>        (default 400)
 import { spawnSync } from "node:child_process";
 
+type TextContent = { type: "text"; text: string };
+type ToolContent = TextContent | { type: string; [key: string]: unknown };
+
 interface ToolResultEvent {
-  content?: unknown;
+  content?: ToolContent[];
   isError?: boolean;
 }
 interface ExtensionAPI {
   on(event: string, handler: (event: ToolResultEvent, ctx: unknown) => unknown): void;
 }
 
-const env = globalThis.process?.env ?? {};
+const runtime = globalThis as typeof globalThis & { process?: NodeJS.Process };
+const env = runtime.process?.env ?? {};
 const MODE = env.HARNESSTRIM_MODE ?? "dryrun";
 const MIN_LENGTH = Number(env.HARNESSTRIM_MINLENGTH ?? "400") || 400;
 const MARKER = "[harnesstrim";
@@ -44,19 +48,28 @@ function reduceViaCli(text: string): string | null {
 export default function harnesstrim(pi: ExtensionAPI): void {
   if (MODE === "off") return;
   pi.on("tool_result", async (event) => {
-    const content = event.content;
-    if (typeof content !== "string" || content.length < MIN_LENGTH) return;
-    if (content.includes(MARKER)) return; // already reduced — avoid double work
+    if (!Array.isArray(event.content)) return;
 
-    const reduced = reduceViaCli(content);
-    if (!reduced || reduced.length >= content.length) return;
+    let changed = false;
+    const content = event.content.map((chunk) => {
+      if (chunk.type !== "text" || typeof chunk.text !== "string") return chunk;
+      const text = chunk.text;
+      if (text.length < MIN_LENGTH || text.includes(MARKER)) return chunk;
 
-    if (MODE === "dryrun") {
-      globalThis.process?.stderr?.write(
-        `[harnesstrim] dryrun tool_result: ${content.length} -> ${reduced.length} chars\n`
-      );
-      return; // dryrun: observe only
-    }
-    return { content: reduced }; // active: patch the tool result the model sees
+      const reduced = reduceViaCli(text);
+      if (!reduced || reduced.length >= text.length) return chunk;
+
+      if (MODE === "dryrun") {
+        runtime.process?.stderr?.write(
+          `[harnesstrim] dryrun tool_result: ${text.length} -> ${reduced.length} chars\n`
+        );
+        return chunk;
+      }
+
+      changed = true;
+      return { ...chunk, text: reduced };
+    });
+
+    return changed ? { content } : undefined;
   });
 }

--- a/packages/adapter-pi/src/index.test.ts
+++ b/packages/adapter-pi/src/index.test.ts
@@ -17,6 +17,11 @@ test("plans the extension into .pi/extensions/harnesstrim", () => {
   assert.equal(plan.alreadyInstalled, false);
 });
 
+test("plans a user install into .pi/agent/extensions/harnesstrim", () => {
+  const plan = planPiInstall({ ...base, scope: "user" });
+  assert.equal(plan.extensionDest, path.join("/proj", ".pi", "agent", "extensions", PI_EXTENSION_NAME));
+});
+
 test("not already-installed when the dir exists but the marker is missing", () => {
   const plan = planPiInstall({ ...base, extensionDirExists: true, markerPresent: false });
   assert.equal(plan.alreadyInstalled, false);

--- a/packages/adapter-pi/src/index.ts
+++ b/packages/adapter-pi/src/index.ts
@@ -31,6 +31,8 @@ export interface PiInstallInput {
   extensionDirExists: boolean;
   /** Whether the `.installed` marker inside the extension dir indicates a prior install. */
   markerPresent: boolean;
+  /** Whether installation targets the user's global Pi extension directory. */
+  scope?: "user" | "project";
 }
 
 /**
@@ -38,7 +40,9 @@ export interface PiInstallInput {
  * considered already installed when its dir exists and the marker is present.
  */
 export function planPiInstall(input: PiInstallInput): PiInstallPlan {
-  const extensionDest = path.join(input.installDir, ".pi", "extensions", PI_EXTENSION_NAME);
+  const extensionDest = input.scope === "user"
+    ? path.join(input.installDir, ".pi", "agent", "extensions", PI_EXTENSION_NAME)
+    : path.join(input.installDir, ".pi", "extensions", PI_EXTENSION_NAME);
   return {
     extensionDest,
     extensionSource: input.extensionSourceDir,

--- a/packages/cli/src/install-pi.test.ts
+++ b/packages/cli/src/install-pi.test.ts
@@ -1,0 +1,18 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runInstallPi } from "./install-pi.ts";
+
+test("runInstallPi --apply refreshes an existing project extension", () => {
+  const project = fs.mkdtempSync(path.join(os.tmpdir(), "htrim-pi-install-"));
+  const first = runInstallPi(project, true);
+  const extension = path.join(first.plan.extensionDest, "harnesstrim.ts");
+  fs.writeFileSync(extension, "stale extension");
+
+  const refreshed = runInstallPi(project, true);
+
+  assert.equal(refreshed.applied, true);
+  assert.equal(fs.readFileSync(extension, "utf8"), fs.readFileSync(path.join(first.plan.extensionSource, "harnesstrim.ts"), "utf8"));
+});

--- a/packages/cli/src/install-pi.ts
+++ b/packages/cli/src/install-pi.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import os from "node:os";
 import { planPiInstall, markerFileContent, type PiInstallPlan } from "@harnesstrim/adapter-pi";
 import { resolvePiExtensionSourceDir } from "./assets.ts";
 
@@ -26,24 +27,27 @@ function markerPresent(dest: string): boolean {
 }
 
 /**
- * Compute (and optionally apply) a Pi install: copy the extension bundle into
- * `<installDir>/.pi/extensions/harnesstrim/`. Dry-run by default; idempotent via a
- * `.installed` marker.
+ * `<installDir>/.pi/extensions/harnesstrim/`. Dry-run by default; `--apply` is
+ * safe to repeat and refreshes the installed extension bundle.
  */
 export function runInstallPi(installDir: string, apply: boolean): PiInstallResult {
   const extensionSourceDir = resolvePiExtensionSourceDir();
-  const dest = path.join(installDir, ".pi", "extensions", "harnesstrim");
+  const scope = path.resolve(installDir) === path.resolve(os.homedir()) ? "user" : "project";
+  const dest = scope === "user"
+    ? path.join(installDir, ".pi", "agent", "extensions", "harnesstrim")
+    : path.join(installDir, ".pi", "extensions", "harnesstrim");
 
   const plan = planPiInstall({
     installDir,
     extensionSourceDir,
     extensionDirExists: dirExists(dest),
     markerPresent: markerPresent(dest),
+    scope,
   });
 
   const copiedFiles: string[] = [];
   let applied = false;
-  if (apply && !plan.alreadyInstalled) {
+  if (apply) {
     fs.mkdirSync(dest, { recursive: true });
     for (const entry of fs.readdirSync(extensionSourceDir, { withFileTypes: true })) {
       if (!entry.isDirectory()) {


### PR DESCRIPTION
## Summary
- reduce text chunks in structured Pi tool results without modifying non-text chunks
- install user-scoped Pi extensions in `~/.pi/agent/extensions` and refresh bundles on every `--apply`
- add a versioned development roadmap to `PLAN.md`

## Verification
- `pnpm --filter @harnesstrim/adapter-pi test`
- `pnpm --filter harnesstrim test`
- `pnpm typecheck`
- built CLI smoke test: `harnesstrim install pi /tmp/harnesstrim-pi-smoke --apply`