### PR TITLE
feat(pi,cli): harnesstrim 0.0.7 — Pi discovery fix, install precision, safe uninstall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 packages/cli/assets/
 *.log
 .DS_Store
+AGENTS.local.md
 benchmarks/reports/*.json
 benchmarks/tierB/reports/
 benchmarks/tierB/*/harnesstrim-metrics.jsonl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,10 +38,12 @@ full paths:
 
 ## Published state (as of last work)
 
-- `harnesstrim` published: latest 0.0.5. 0.0.6 (lint-output-slim reducer, install/readStdin
-  hang fixes, clean-package smoke test) is in PR.
+- `harnesstrim` published: latest 0.0.6 (2026-08-01). 0.0.7 in flight (uncommitted on
+  `feat/install-precision-json-uninstall`): Pi discovery fix (`index.ts`), install-precision
+  narrowing, `--json`/`capabilities`, `uninstall`, TrimEvent schema, extended smoke test.
 - CLI features already present: `doctor`, `install opencode|codex|claude|hermes|pi`,
-  `hook claude`, `reduce`, `mcp`, `bench`, `preset list/show`, `metrics`, `--version`.
+  `hook claude`, `reduce`, `mcp`, `bench`, `preset list/show`, `metrics`, `--version`,
+  `capabilities`, `uninstall`, `--json` on doctor/install/metrics.
 - All five harness adapters exist (opencode/claude/codex/hermes/pi hooks; codex via
   instruction + MCP).
 - CI: `.github/workflows/ci.yml` (typecheck/test/bench on 3 OS + hermes plugin tests).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,6 @@ making changes.
 The repo uses pnpm, but `pnpm` and `opencode` are NOT always on the session PATH. Use the
 full paths:
 
-```sh
-export PATH="$HOME/.nvm/versions/node/v24.13.0/bin:$HOME/.opencode/bin:$PATH"
-```
 
 - Typecheck: `npm run typecheck`
 - Test: `npm test`
@@ -29,14 +26,6 @@ export PATH="$HOME/.nvm/versions/node/v24.13.0/bin:$HOME/.opencode/bin:$PATH"
 
 ## Git / remotes
 
-- `origin` = https://github.com/giuliastro/HarnessTrim.git (read-only access from this account)
-- `gervaso` = https://github.com/gervaso-assistant/HarnessTrim.git (write access, token via gh keyring)
-- Active gh account: `gervaso-assistant` (git protocol: ssh). Push flow = push to `gervaso`
-  branch, open a PR into `giuliastro/HarnessTrim` via `gh pr create --repo giuliastro/HarnessTrim`.
-- `harnesstrim` lives at `~/.opencode/bin/opencode` (1.18.x) — not on the session PATH.
-- Credentials: gh token lives in the Zorin keyring; it is NOT readable programmatically
-  from a non-graphical shell (collections come back locked). Do not attempt to read it.
-- Only commit/push when the user explicitly asks.
 
 ## Benchmarks / token accounting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,9 @@ making changes.
 
 ## Commands
 
-The repo uses pnpm, but `pnpm` and `opencode` are NOT always on the session PATH. Use the
-full paths:
-
+The repo uses pnpm, but `pnpm` and `opencode` are NOT always on the session PATH. Ensure
+they are on the session PATH (machine-specific toolchain paths live in AGENTS.local.md,
+which is git-ignored — not in this file).
 
 - Typecheck: `npm run typecheck`
 - Test: `npm test`
@@ -24,8 +24,10 @@ full paths:
   `node --experimental-strip-types benchmarks/src/run.ts`
 - CLI build (esbuild bundle + staged assets): `node packages/cli/build.mjs`
 
-## Git / remotes
+## Git
 
+- Only commit/push when the user explicitly asks.
+- Remote/push conventions are machine-specific; see AGENTS.local.md.
 
 ## Benchmarks / token accounting
 
@@ -38,9 +40,9 @@ full paths:
 
 ## Published state (as of last work)
 
-- `harnesstrim` published: latest 0.0.6 (2026-08-01). 0.0.7 in flight (uncommitted on
-  `feat/install-precision-json-uninstall`): Pi discovery fix (`index.ts`), install-precision
-  narrowing, `--json`/`capabilities`, `uninstall`, TrimEvent schema, extended smoke test.
+- `harnesstrim` published: latest 0.0.6 (2026-08-01). 0.0.7 in flight (open PR): Pi
+  discovery fix (`index.ts`), install-precision narrowing, `--json`/`capabilities`,
+  `uninstall`, TrimEvent schema, extended smoke test.
 - CLI features already present: `doctor`, `install opencode|codex|claude|hermes|pi`,
   `hook claude`, `reduce`, `mcp`, `bench`, `preset list/show`, `metrics`, `--version`,
   `capabilities`, `uninstall`, `--json` on doctor/install/metrics.

--- a/PLAN.md
+++ b/PLAN.md
@@ -280,6 +280,15 @@ OpenCode plugins run on — this is a deliberate exception, not an inconsistency
 Pi integration uncertainty.
 
 - Ship `--version`/`-v` in the CLI and preserve the bundled-asset resolver for every installer.
+- **DONE — 2026-08-01** Install-precision and machine-readable surfaces (`docs/token-harness-onboarding.md`):
+  per-harness narrowing (`--no-hook`/`--no-instructions` for Claude/Codex skills-only installs;
+  OpenCode `--mode`/`--min-length`/`--tools` baked into the generated wrapper); `--json` output for
+  `doctor`/`install`/`metrics`; a `capabilities` command exposing each harness's adapter surface,
+  narrowing flags, and exact write-set; a dry-run-first `uninstall <harness>` that only removes what
+  HarnessTrim wrote (marker-guarded instruction regions, copied skills + now-empty parent dir, added
+  hook entries, OpenCode wrapper + dependency); and telemetry hardening (`schemaVersion` + stable
+  `eventId` on every TrimEvent, legacy JSONL lines normalized, emitters updated in the OpenCode/MCP
+  hooks and Hermes plugin). 169 tests, typecheck clean.
 - Validate Pi's structured `tool_result.content` against a live Pi session in both `dryrun` and
   `active` modes. Confirm that text chunks shrink, non-text chunks are unchanged, failed reductions
   pass through, and the marker prevents a second reduction.
@@ -329,6 +338,31 @@ multi-tool Tier B evidence are all repeatable.
 
 ## 10. Status log
 
+
+- **2026-08-01** — **Install-precision, machine-readable output, safe uninstall, telemetry hardening
+  (v0.0.6, per `docs/token-harness-onboarding.md`).** Implemented on `feat/generic-reducers-hermes`
+  (rebased onto origin/main):
+  - **Narrowed installs:** `install claude --no-hook` / `--no-instructions` and `install codex
+    --no-instructions` do skills-only installs (planners honor `includeHook`/`includeInstructions`;
+    nothing else is touched). `install opencode --mode active|dryrun|off`, `--min-length <n>`, and
+    `--tools <name,...>` bake their overrides into the generated wrapper config.
+  - **Machine-readable output:** `doctor`, `install <harness>`, and `metrics` accept `--json`
+    (`packages/cli/src/json.ts`). `capabilities` prints a JSON table of what this build supports per
+    harness: adapter surface, available narrowing flags, and the exact write-set each installer owns.
+  - **`uninstall <harness>`** (`packages/cli/src/uninstall.ts`): dry-run until `--apply`; only removes
+    what HarnessTrim wrote — marker-guarded instruction regions, the copied skill dirs (and a now-empty
+    parent skills dir), the hook entries it added, and the OpenCode wrapper + package.json dependency.
+    Parent-dir and package.json handling were fixed during the test pass (3 failures → 0).
+  - **Telemetry hardening:** every TrimEvent now carries `schemaVersion: 1` and a stable `eventId`
+    (randomUUID), with `beforeTokens`/`afterTokens` nullable; `makeTrimEvent()` is the single emitter
+    in the OpenCode plugin, MCP server, and CLI hook/reduce paths; the Hermes Python plugin writes the
+    same shape; `parseTrimEvents` normalizes legacy schemaVersion-0 lines. `TrimEvent` schema remains
+    backward-compatible for `metrics` summaries.
+  - 169 tests green (core 66, cli 45, adapter-claude 19, adapter-codex 16, adapter-opencode 9,
+    adapter-hermes/pi 5 each, mcp 4), typecheck clean on all packages. Smoke-tested live: `--json`
+    install/uninstall/doctor/metrics, `--no-hook` install, and `uninstall --apply` from a scratch dir.
+  - Next: package + publish v0.0.6 (lint-output-slim reducer + these changes are queued in PR); then
+    the §9 v0.1.0 release CI and v0.2.0 Tier B matrix.
 
 - **RESUME HERE (next session).** Repo is green: CI passes on Linux/Windows/macOS, 119 tests,
   typecheck clean, bench fidelity OK. **`harnesstrim` is LIVE on npm and verified working end-to-end**

--- a/PLAN.md
+++ b/PLAN.md
@@ -277,7 +277,7 @@ OpenCode plugins run on — this is a deliberate exception, not an inconsistency
 ### v0.0.6 — installation and adapter hardening
 
 **Goal:** make every published CLI path work from a clean npm installation and close the remaining
-Pi integration uncertainty.
+Pi integration uncertainty (resolved 2026-08-02 — Pi live-verified on 0.82.1).
 
 - Ship `--version`/`-v` in the CLI and preserve the bundled-asset resolver for every installer.
 - **DONE — 2026-08-01** Install-precision and machine-readable surfaces (`docs/token-harness-onboarding.md`):
@@ -292,10 +292,23 @@ Pi integration uncertainty.
 - Validate Pi's structured `tool_result.content` against a live Pi session in both `dryrun` and
   `active` modes. Confirm that text chunks shrink, non-text chunks are unchanged, failed reductions
   pass through, and the marker prevents a second reduction.
+- **DONE — 2026-08-02** Pi live hardening on Pi 0.82.1 (see status log). Root-cause fix found: Pi's
+  loader only auto-discovers a *subdirectory* extension via `index.ts`/`index.js` or a `package.json`
+  with a `pi.extensions` field — the installer wrote `harnesstrim/harnesstrim.ts`, which was never
+  loaded. Renamed the entry point to `harnesstrim/index.ts`, made the installer prune stale bundle
+  files on refresh, and added a `shouldSkip` unit test for the extension's non-text/marker-guard paths.
 - Test both Pi install scopes: project (`<project>/.pi/extensions`) and user
   (`~/.pi/agent/extensions`), including a second `--apply` that refreshes the bundle.
 - Add a clean-package smoke test that runs each installer from `npm pack` output, so source-layout
   assumptions cannot regress.
+- **DONE — 2026-08-02** Clean-package smoke test (`packages/cli/smoke-test.sh`) extended and fixed:
+  covers all five installers dry-run/apply/idempotent, the new v0.0.7 surfaces (narrowing flags,
+  `--json` for doctor/install, `capabilities`, `uninstall` dry-run + apply), `--min-length` threshold
+  semantics, and the MCP/bench/metrics paths. Fixed during the pass: the reduce check used a lint wall
+  below the 400-char min-length (never reduced); narrowed installs (`--no-hook`/`--no-instructions`)
+  now render an explicit "skipped" state instead of a false "already present" (new `"skip"` plan
+  action on Claude settings/instructions and Codex instructions); and `uninstall opencode` removes a
+  plugin dir that contained only our wrapper. 175 tests, typecheck clean, smoke green.
 
 **Exit criteria:** live Pi proof recorded; packaged CLI installation smoke tests pass; every adapter's
 documented install path works from an empty directory.
@@ -339,9 +352,59 @@ multi-tool Tier B evidence are all repeatable.
 ## 10. Status log
 
 
+- **2026-08-02** — **Pi adapter live-hardened and VERIFIED on Pi 0.82.1** (the last §9 v0.0.6
+  uncertainty). Pi is installed (`pi` 0.82.1, provider `opencode`, model `deepseek-v4-flash-free`).
+  What happened:
+  - **Root-cause discovery fix (the important part):** the installed extension was never loaded. Pi's
+    loader (`dist/core/extensions/loader.js`) only discovers a *subdirectory* extension via
+    `index.ts`/`index.js` or a `package.json` with a `pi.extensions` field; our installer wrote
+    `harnesstrim/harnesstrim.ts`, which Pi silently ignored. Renamed the entry point to
+    `packages/adapter-pi/extension/index.ts`, and `runInstallPi` now prunes stale bundle files on
+    refresh so the installed dir always mirrors the shipped bundle. Verified in both scopes
+    (`~/.pi/agent/extensions/` user + `<project>/.pi/extensions/` project).
+  - **Live dry-run:** default `HARNESSTRIM_MODE=dryrun` — `tool_result` fires on `bash` and `read`,
+    logs `[harnesstrim] dryrun tool_result: N -> M chars` to stderr, changes nothing.
+  - **Live active:** `HARNESSTRIM_MODE=active` — a 13902-char JSON array (`cat noisy.json`) reached
+    the model as **6 lines (3 first + 3 last + `... omitted 74 items ...`)** via `json-output-slim`;
+    the model independently confirmed it could NOT see id 40 (the omitted middle) and could count only
+    the 6 visible entries. The `read` tool was trimmed the same way.
+  - **Failure safety (live):** with `harnesstrim` removed from PATH, the same file passed through
+    untouched (model counted all 80 entries). Already-reduced output (carrying the `[harnesstrim`
+    marker) was NOT reduced again.
+  - New `packages/adapter-pi/src/extension.test.ts` unit-tests `shouldSkip` (min-length boundary,
+    marker guard, pass-through). adapter-pi suite now 9 tests; **173 tests total, typecheck clean**;
+    Tier A bench still passes fidelity. Docs updated (adapter-pi README Status, root README Pi
+    section + Status + count, PLAN §9).
+  - **Smoke test DONE (same day):** `packages/cli/smoke-test.sh` extended and fixed (see the follow-up
+    below), so the remaining v0.0.6 roadmap item is closed — the fixes ship in `harnesstrim@0.0.7`.
+    Next version is §9 v0.1.0 (telemetry-driven reducers, metrics depth, release CI).
+
+- **2026-08-02** — **Clean-package smoke test extended + two honesty/precision fixes (v0.0.7, DONE).**
+  (`0.0.6` was already published on 2026-08-01 from `de365e7`/`origin/main` — this work and the
+  install-precision commit `122d05a` ship in the next release, **`harnesstrim@0.0.7`**.)
+  `packages/cli/smoke-test.sh` now runs every installer from `npm pack` output and checks: `--version`,
+  zero runtime deps in the packed tarball, all five installers apply (with their assets present), the
+  MCP/bench/metrics paths, narrowed installs (`--no-hook`/`--no-instructions`), opencode
+  `--mode dryrun --min-length 2000 --tools bash,read` wrapper config, `capabilities` JSON listing all
+  five harnesses, `doctor --json`/`install --json` parse, and `uninstall` dry-run vs `--apply` for
+  pi/opencode/claude. Fixed during the pass:
+  - The reduce check fed a lint wall **below the 400-char min-length**, so lint-output-slim never
+    reduced; the sample is now a 30-line wall, and a `--min-length 999999` pass-through check pins the
+    threshold semantics (`--min-length` can only *raise* the floor, never lower below 400).
+  - **"skip" plan action for narrowed installs:** `--no-hook`/`--no-instructions` previously rendered
+    a false "already present (no change)" because the planners reported `"present"` for excluded
+    surfaces. Added `"skip"` to `InstructionsAction` (adapter-codex + adapter-claude) and
+    `SettingsAction` (adapter-claude); planners/runners/render/json all honor it ("hook skipped
+    (--no-hook); skills only"), and `changed` now ignores both `"present"` and `"skip"` so a skills-only
+    re-install stays idempotent.
+  - **`uninstall opencode` now removes the plugin dir** when it contained only our wrapper (the
+    previous emptiness check ran at plan time while the wrapper still existed, so it never fired).
+  - 175 tests (cli 45→47), typecheck clean, smoke green, Tier A bench still passes fidelity.
+
+
 - **2026-08-01** — **Install-precision, machine-readable output, safe uninstall, telemetry hardening
-  (v0.0.6, per `docs/token-harness-onboarding.md`).** Implemented on `feat/generic-reducers-hermes`
-  (rebased onto origin/main):
+  (ships in v0.0.7, per `docs/token-harness-onboarding.md`).** Implemented on
+  `feat/install-precision-json-uninstall` (pushed to gervaso, unmerged):
   - **Narrowed installs:** `install claude --no-hook` / `--no-instructions` and `install codex
     --no-instructions` do skills-only installs (planners honor `includeHook`/`includeInstructions`;
     nothing else is touched). `install opencode --mode active|dryrun|off`, `--min-length <n>`, and
@@ -361,7 +424,7 @@ multi-tool Tier B evidence are all repeatable.
   - 169 tests green (core 66, cli 45, adapter-claude 19, adapter-codex 16, adapter-opencode 9,
     adapter-hermes/pi 5 each, mcp 4), typecheck clean on all packages. Smoke-tested live: `--json`
     install/uninstall/doctor/metrics, `--no-hook` install, and `uninstall --apply` from a scratch dir.
-  - Next: package + publish v0.0.6 (lint-output-slim reducer + these changes are queued in PR); then
+  - Next: package + publish v0.0.7 (these changes + the Pi/smoke-test fixes); then
     the §9 v0.1.0 release CI and v0.2.0 Tier B matrix.
 
 - **RESUME HERE (next session).** Repo is green: CI passes on Linux/Windows/macOS, 119 tests,
@@ -383,8 +446,8 @@ multi-tool Tier B evidence are all repeatable.
      `settings.local.json` hooks mid-session** (no restart needed — the old "needs a restart" guess was
      wrong on two counts). Follow-up: file the bug (draft in the 2026-07-17 entry). Claude Code users
      get deterministic reduction today via the MCP `reduce` tool or the `harnesstrim reduce` pipe.
-  3. Pi live hardening (needs the Pi CLI installed); coverage-driven new reducers (needs accumulated
-     real telemetry from `.harnesstrim/metrics.jsonl`).
+   3. **[DONE — 2026-08-02]** Pi live hardening (see the 2026-08-02 entry); coverage-driven new reducers
+      (needs accumulated real telemetry from `.harnesstrim/metrics.jsonl`).
   4. Follow-ups on the live package: publish skills as part of the package or a `create` flow; add a
      CI release job; consider `harnesstrim@0.0.x` → `0.1.0` once Tier B numbers land.
   Dogfooding is live: the Claude PostToolUse hook (in `.claude/settings.local.json`, gitignored)

--- a/README.md
+++ b/README.md
@@ -261,13 +261,18 @@ Phases 0–4 in progress. Shipped: reducers + benchmark, the 6-skill pack, adapt
 (runtime plugin, hardened in a live session), **Codex** (skills + AGENTS.md reduce-pipe, live-validated
 via `codex debug prompt-input`), **Claude Code** (PostToolUse reducer hook), **Hermes Agent**
 (`transform_tool_result` plugin, verified in a live session), and **Pi** (`tool_result` extension),
-plus an MCP `reduce` server, the `harnesstrim` CLI (doctor / install / preset / metrics / reduce /
+plus an MCP `reduce` server, the `harnesstrim` CLI (doctor / install / uninstall / capabilities / preset / metrics / reduce /
 hook / mcp / bench), telemetry, and policy presets. All five target harnesses now have an adapter.
 The CLI is **published on npm** (`npx harnesstrim`) as a single self-contained bundle.
 End-to-end Tier B runs on OpenCode (two tasks × two runs, quality retained in all 8) measured billed-token
 savings of **~2% on a tiny one-tool-call task and ~22–25% on a large-noisy-output task**, with the prompt
 cache preserved — the blended win scales with noisy-output volume vs fixed overhead. A larger multi-model,
-multi-tool-call study is the remaining Tier B work. 131 tests passing, typecheck clean on all packages.
+multi-tool-call study is the remaining Tier B work. 169 tests passing, typecheck clean on all packages.
+Installers support **narrowing** (skills-only installs via `--no-hook`/`--no-instructions`, OpenCode
+`--mode`/`--min-length`/`--tools` baked into the wrapper), `doctor`/`install`/`metrics` emit **`--json`**,
+`capabilities` reports per-harness surfaces/write-sets as JSON, and `uninstall` reverses an install
+dry-run-first (only removing what HarnessTrim wrote, marker-guarded). Telemetry lines carry a schema
+version and a stable event id.
 
 > **Known limitation (Claude Code):** the `PostToolUse` reducer hook installs and fires correctly, but
 > Claude Code (verified on 2.1.37 and 2.1.212) does not currently apply a hook's `updatedToolOutput`,
@@ -285,7 +290,8 @@ packages/adapter-claude/    Claude Code: PostToolUse reducer hook + skill bundle
 packages/adapter-hermes/    Hermes Agent: transform_tool_result reducer plugin (Python)
 packages/adapter-pi/        Pi: tool_result reducer extension (TypeScript)
 packages/mcp/               MCP server exposing a `reduce` tool (Codex, Claude Code, any MCP client)
-packages/cli/               harnesstrim CLI: doctor, install, preset, metrics, reduce, hook, mcp, bench
+packages/cli/               harnesstrim CLI: doctor, install, uninstall, capabilities, preset,
+                            metrics, reduce, hook, mcp, bench
 skills/                     portable Agent Skills (delta-response, debug-log-slim, review-delta,
                             compact-handoff, scaffold-fast, delegate-bulk)
 benchmarks/                 Tier A micro-benchmarks: reducer token-reduction, no LLM involved
@@ -298,14 +304,23 @@ examples/opencode/          minimal .opencode/ local-plugin wrapper wiring the a
 pnpm exec harnesstrim doctor [dir]            # diagnose token-waste signals in a project
 pnpm exec harnesstrim install opencode [dir]  # OpenCode: local plugin wrapper in .opencode/ (dry-run)
 pnpm exec harnesstrim install opencode --preset lean-debug --apply
+pnpm exec harnesstrim install opencode --mode dryrun --apply      # preview without reducing
+pnpm exec harnesstrim install opencode --min-length 2000 --apply  # leave outputs <2k chars untouched
+pnpm exec harnesstrim install opencode --tools bash,read --apply  # reduce only bash + read output
 pnpm exec harnesstrim install codex [dir]     # Codex: skills + AGENTS.md reduce-pipe (dry-run)
                                              # add --hook for experimental automatic Bash reduction
                                              # add --hook --global to install it once in ~/.codex
+                                             # add --no-instructions for skills only
 pnpm exec harnesstrim install claude [dir]    # Claude Code: skills + PostToolUse hook (dry-run)
+pnpm exec harnesstrim install claude --no-hook --apply            # skills + CLAUDE.md, no hook
 pnpm exec harnesstrim install hermes [dir]    # Hermes Agent: transform_tool_result plugin (dry-run)
 pnpm exec harnesstrim install pi [dir]        # Pi: tool_result extension (dry-run)
+pnpm exec harnesstrim uninstall claude [dir]  # reverse an install, dry-run (add --apply to remove)
+pnpm exec harnesstrim capabilities            # per-harness capabilities / write-sets as JSON
 pnpm exec harnesstrim preset list             # list policy presets
 pnpm exec harnesstrim metrics [path]          # summarize adapter telemetry (JSONL)
+pnpm exec harnesstrim doctor --json           # any command emitting a report accepts --json
+pnpm exec harnesstrim metrics --json          # machine-readable telemetry summary
 npm test 2>&1 | pnpm exec harnesstrim reduce  # pipe: slim noisy output (Codex/Claude/shell)
 npm test 2>&1 | pnpm exec harnesstrim reduce --metrics .harnesstrim/metrics.jsonl  # + record the saving
 pnpm exec harnesstrim bench                    # run the Tier A reducer micro-benchmark
@@ -316,9 +331,19 @@ pnpm exec harnesstrim bench                    # run the Tier A reducer micro-be
 - `install <harness>` is dry-run until `--apply`. Each adapter uses that harness's native surface:
   OpenCode a `tool.execute.after` plugin, Claude Code a `PostToolUse` hook, Hermes a
   `transform_tool_result` plugin, Pi a `tool_result` extension, Codex an AGENTS.md reduce-pipe
-  instruction. `--preset` (OpenCode) bakes a policy preset's adapter config in.
+  instruction. `--preset` (OpenCode) bakes a policy preset's adapter config in. Installs can be
+  **narrowed** per harness: `--no-hook`/`--no-instructions` (Claude/Codex) install skills only,
+  and OpenCode's `--mode active|dryrun|off`, `--min-length <n>`, and `--tools <list>` overrides
+  are baked into the generated wrapper.
+- `uninstall <harness>` reverses an install. It is dry-run until `--apply` and only touches files
+  HarnessTrim wrote: marker-guarded instruction regions, the skills it copied (including a now-empty
+  parent skills dir), hook entries it added, and the OpenCode wrapper/dependency.
+- `capabilities` prints a JSON table of what this build supports per harness: adapter surface,
+  available narrowing flags, and the exact write-set each installer owns.
+- `doctor`, `install`, and `metrics` accept `--json` for machine-readable output (scripts/CI).
 - `reduce` is the pipe-friendly reducer (RTK-style) shared across harnesses.
 - `metrics` aggregates the telemetry the adapter emits (off by default) into chars saved per reducer.
+  Lines carry a schema version and a stable event id.
 
 ## Try it
 
@@ -359,6 +384,16 @@ harness. "dry-run mode" here means the adapter logs what it *would* slim without
 Guidance: for the dry-run adapters (Hermes, Pi) keep the default while you confirm it slims the right
 things (watch stderr for `[harnesstrim] dryrun ...` lines), then flip to `active` persistently.
 Telemetry is **off by default everywhere**; enable it only where you want a metrics trail.
+
+Telemetry lines are JSONL with a schema version and a stable event id, e.g.:
+
+```jsonl
+{"schemaVersion":1,"eventId":"…","ts":"2026-08-01T…","harness":"opencode","tool":"bash","reducer":"test-output-slim","beforeChars":1410,"afterChars":124,"beforeTokens":null,"afterTokens":null}
+```
+
+`beforeTokens`/`afterTokens` are `null` unless the emitting path has real counts (no tokenizer runs in
+the harness process). `harnesstrim metrics <path>` aggregates these; legacy schemaVersion-0 lines are
+still accepted.
 
 ### OpenCode
 

--- a/README.md
+++ b/README.md
@@ -260,14 +260,15 @@ xychart-beta
 Phases 0–4 in progress. Shipped: reducers + benchmark, the 6-skill pack, adapters for **OpenCode**
 (runtime plugin, hardened in a live session), **Codex** (skills + AGENTS.md reduce-pipe, live-validated
 via `codex debug prompt-input`), **Claude Code** (PostToolUse reducer hook), **Hermes Agent**
-(`transform_tool_result` plugin, verified in a live session), and **Pi** (`tool_result` extension),
+(`transform_tool_result` plugin, verified in a live session), and **Pi** (`tool_result` extension,
+verified live on 0.82.1),
 plus an MCP `reduce` server, the `harnesstrim` CLI (doctor / install / uninstall / capabilities / preset / metrics / reduce /
 hook / mcp / bench), telemetry, and policy presets. All five target harnesses now have an adapter.
 The CLI is **published on npm** (`npx harnesstrim`) as a single self-contained bundle.
 End-to-end Tier B runs on OpenCode (two tasks × two runs, quality retained in all 8) measured billed-token
 savings of **~2% on a tiny one-tool-call task and ~22–25% on a large-noisy-output task**, with the prompt
 cache preserved — the blended win scales with noisy-output volume vs fixed overhead. A larger multi-model,
-multi-tool-call study is the remaining Tier B work. 169 tests passing, typecheck clean on all packages.
+multi-tool-call study is the remaining Tier B work. 175 tests passing, typecheck clean on all packages.
 Installers support **narrowing** (skills-only installs via `--no-hook`/`--no-instructions`, OpenCode
 `--mode`/`--min-length`/`--tools` baked into the wrapper), `doctor`/`install`/`metrics` emit **`--json`**,
 `capabilities` reports per-harness surfaces/write-sets as JSON, and `uninstall` reverses an install
@@ -505,7 +506,12 @@ harnesstrim install pi ~ --apply           # global: ~/.pi/... (pass your home d
 
 Copies a TypeScript extension that hooks Pi's `tool_result` and slims noisy output via
 `harnesstrim reduce` (so `harnesstrim` must be on PATH). It starts in `dryrun`; set
-`HARNESSTRIM_MODE=active` in Pi's environment to reduce. Details:
+`HARNESSTRIM_MODE=active` in Pi's environment to reduce. **Verified live on Pi 0.82.1:** the
+extension ships as `harnesstrim/index.ts` because Pi's loader only auto-discovers a subdirectory
+extension via `index.ts` (or a `package.json` with a `pi.extensions` field); dryrun logs
+`[harnesstrim] dryrun ...` to stderr, active mode replaces text chunks (a 13902-char JSON array
+reached the model as 6 lines), output passes through when `harnesstrim` is missing, and already-reduced
+output is never reduced twice. Details:
 [`packages/adapter-pi`](packages/adapter-pi/README.md).
 
 ### Any MCP-capable harness

--- a/docs/token-harness-onboarding.md
+++ b/docs/token-harness-onboarding.md
@@ -1,0 +1,114 @@
+# Task: install-precision, scriptable output, and safe uninstall for HarnessTrim
+
+You are working in the HarnessTrim monorepo (giuliastro/HarnessTrim). Read AGENTS.md
+and PLAN.md first — they are the source of truth for conventions (pnpm workspace,
+Node 24 native TS with literal `.ts` import specifiers, dry-run-by-default installers,
+telemetry off by default, deterministic/idempotent/cache-aware reducers, zero runtime
+deps in the published `harnesstrim` CLI bundle).
+
+## Background (why)
+
+The installer is dry-run by default and idempotent, which is a good foundation. But a
+few gaps make the CLI hard to use precisely and safely — both interactively and from
+scripts:
+
+- The installer produces only one fixed shape per harness: skills + hook + CLAUDE.md
+  guidance on Claude, skills + AGENTS.md guidance on Codex, and a `mode: "active"`
+  baked into a generated wrapper on OpenCode. There is no way to ask for a *narrower*
+  install (skills only, or `dryrun` mode), so installs are more invasive than they need
+  to be and cannot be composed with other tools.
+- `doctor` and `metrics` render prose only, so their results cannot be consumed by
+  scripts or other tools without parsing.
+- Nothing states, in a machine-readable way, what this version supports per harness —
+  discovery is manual and version-checking is impossible.
+- There is no `uninstall`: removing an install means editing several files by hand.
+- The telemetry stream has no schema version and no stable event ID, so it cannot be
+  versioned, deduplicated, or evolved safely.
+
+This is general product quality for HarnessTrim itself, not a feature request from a
+specific downstream tool. Design and name each item as a normal HarnessTrim feature,
+self-contained and useful from this CLI on its own. (A downstream tool happens to
+consume this CLI too; that must never require a HarnessTrim-specific concept — keep
+everything generic.)
+
+Implement the items below, in this priority order.
+
+## 1. Per-surface narrowing (highest priority)
+
+The installer must be able to produce each narrower state its adapters can represent:
+
+- **`install claude`** (`packages/adapter-claude/src/install.ts`): skills + Bash hook +
+  CLAUDE.md instruction install as one unit (`HOOK_MATCHER = "Bash"`, line 6). Add a
+  flag to install skills without the hook (e.g. `--no-hook`) and one to skip the
+  marker-guarded `REDUCE_INSTRUCTION_SNIPPET` (lines 18–29). `planClaudeInstall` must
+  stay pure — thread the options through its input and surface the resulting actions.
+- **`install codex`** (`packages/adapter-codex/src/index.ts`): `planCodexInstall` always
+  writes `REDUCE_INSTRUCTION_SNIPPET` into AGENTS.md (lines 23–34). Add a flag (e.g.
+  `--no-instructions`) to produce skills-only.
+- **`install opencode`** (`packages/cli/src/install.ts`): `DEFAULT_OPENCODE_ADAPTER_CONFIG`
+  (lines 15–19) and every preset force `mode: "active"`, baked into the generated wrapper.
+  Expose `--mode active|dryrun|off` and `--min-length <n>` as CLI flags;
+  `runInstallOpencode` already accepts an `adapterConfig` override (line 124) — thread the
+  flags through `cli.ts`.
+- **Ideal, if cheap:** a per-surface selector confining reduction to a subset of tool
+  families on OpenCode (use `input.tool` as a filter in `tool.execute.after`, currently
+  ignored at `packages/adapter-opencode/src/plugin.ts:37`). This lets users install the
+  adapter for only the surfaces they want.
+
+Acceptance per harness: a documented CLI invocation produces the narrowed state; a unit
+test asserts `plan*Install` returns `changed: false` on re-run for that state and `apply`
+writes only the intended files.
+
+## 2. Machine-readable output (`--json`)
+
+Add a global `--json` flag to `doctor` (`packages/cli/src/doctor.ts`) and `metrics`
+(`packages/cli/src/metrics.ts`), and ideally to `install <harness>` (emit the computed
+plan as JSON: actions, target paths, whether anything changes) instead of the rendered
+prose. One JSON object on stdout; human rendering stays the default. The CLI's own
+results must be consumable by scripts and other tools without parsing prose.
+
+## 3. New `capabilities` command
+
+Add `harnesstrim capabilities` (JSON): per supported harness, the reduction surface(s) it
+implements, the narrowed states the installer can produce (and via which flags), and the
+reviewed write set (files/directories `install <harness>` writes or modifies). This makes
+what this version supports discoverable and version-checkable by scripts, CI, and any
+consumer, and removes the need to hardcode a per-version capability table anywhere.
+Keep the data in one source in the repo; the command serializes it.
+
+## 4. New `uninstall` command
+
+Add `harnesstrim uninstall <harness>` that removes only what the installer wrote, using
+the existing marker fences (`harnesstrim:begin`/`harnesstrim:end` in instruction files;
+`hasHarnessTrimHook`/hook removal for `.claude/settings.json` and `.codex/hooks.json`;
+the wrapper + `.opencode/package.json` dependency for OpenCode; the `.installed` marker
+for Hermes). Dry-run by default, `--apply` to write. Never touch files it did not create
+or marker-guarded regions.
+
+## 5. Telemetry stream hardening
+
+`TrimEvent` (`packages/core/src/metrics/trim-event.ts`) carries ts/harness/tool/reducer/
+beforeChars/afterChars. Add: `schemaVersion` (start at 1; keep `parseTrimEvents` accepting
+legacy lines), a stable event ID (so readers dedupe without synthesizing one), and token
+counts only where the emitting path has them (`null` otherwise — do not bundle a
+tokenizer into the harness process). Update the JSONL examples in README/docs.
+
+## Constraints
+
+- Installers stay **dry-run by default**; nothing written without `--apply`.
+- **Telemetry stays opt-in**; never change defaults that would enable it.
+- Do not change core reducer semantics; keep them deterministic, idempotent, cache-aware.
+- Keep the published CLI **zero runtime dependencies** (esbuild bundle,
+  `packages/cli/build.mjs`): `--json`/`capabilities` must not pull in a JSON library.
+- New flags keep backward compatibility (existing invocations unchanged).
+- Relative imports use the literal `.ts` extension. Run `npm run typecheck` and `npm test`;
+  keep the whole suite green.
+
+## Deliverables
+
+- Code + unit tests per item, following the repo's `node --test` style (`.test.ts` beside
+  source).
+- Update the `HELP` text (`packages/cli/src/cli.ts`), README, and append a dated entry to
+  PLAN.md's status log describing what changed and why.
+- Do not commit or push. Report back: what was implemented, test/typecheck status, and
+  anything harder or different than planned.

--- a/packages/adapter-claude/src/install.test.ts
+++ b/packages/adapter-claude/src/install.test.ts
@@ -74,7 +74,7 @@ test("CLAUDE.md instruction: present (idempotent) when the marker is already the
 
 test("includeHook:false produces a skills-only state (no settings change)", () => {
   const plan = planClaudeInstall({ ...base, includeHook: false });
-  assert.equal(plan.settingsAction, "present");
+  assert.equal(plan.settingsAction, "skip");
   assert.deepEqual(plan.nextSettings, {});
   assert.equal(plan.instructionsAction, "create");
 });
@@ -85,13 +85,13 @@ test("includeHook:false never patches existing settings", () => {
     hooks: { PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "other" }] }] },
   });
   const plan = planClaudeInstall({ ...base, settingsJsonContent: existing, includeHook: false });
-  assert.equal(plan.settingsAction, "present");
+  assert.equal(plan.settingsAction, "skip");
   assert.equal(plan.nextSettings.model, "sonnet");
 });
 
 test("includeInstructions:false produces a skills-only state (no CLAUDE.md change)", () => {
   const plan = planClaudeInstall({ ...base, includeInstructions: false });
-  assert.equal(plan.instructionsAction, "present");
+  assert.equal(plan.instructionsAction, "skip");
   assert.equal(plan.settingsAction, "create");
 });
 

--- a/packages/adapter-claude/src/install.test.ts
+++ b/packages/adapter-claude/src/install.test.ts
@@ -71,3 +71,38 @@ test("CLAUDE.md instruction: present (idempotent) when the marker is already the
   const plan = planClaudeInstall({ ...base, claudeMdContent: `stuff\n<!-- ${HARNESSTRIM_MARKER} -->\n` });
   assert.equal(plan.instructionsAction, "present");
 });
+
+test("includeHook:false produces a skills-only state (no settings change)", () => {
+  const plan = planClaudeInstall({ ...base, includeHook: false });
+  assert.equal(plan.settingsAction, "present");
+  assert.deepEqual(plan.nextSettings, {});
+  assert.equal(plan.instructionsAction, "create");
+});
+
+test("includeHook:false never patches existing settings", () => {
+  const existing = JSON.stringify({
+    model: "sonnet",
+    hooks: { PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "other" }] }] },
+  });
+  const plan = planClaudeInstall({ ...base, settingsJsonContent: existing, includeHook: false });
+  assert.equal(plan.settingsAction, "present");
+  assert.equal(plan.nextSettings.model, "sonnet");
+});
+
+test("includeInstructions:false produces a skills-only state (no CLAUDE.md change)", () => {
+  const plan = planClaudeInstall({ ...base, includeInstructions: false });
+  assert.equal(plan.instructionsAction, "present");
+  assert.equal(plan.settingsAction, "create");
+});
+
+test("plan.changed is false when a skills-only install is already in that state", () => {
+  const first = planClaudeInstall({ ...base, includeHook: false, includeInstructions: false });
+  assert.equal(first.changed, true); // skills missing
+  const rerun = planClaudeInstall({
+    ...base,
+    includeHook: false,
+    includeInstructions: false,
+    existingSkillNames: base.skillNames,
+  });
+  assert.equal(rerun.changed, false);
+});

--- a/packages/adapter-claude/src/install.ts
+++ b/packages/adapter-claude/src/install.ts
@@ -50,6 +50,8 @@ export interface ClaudeInstallPlan {
   instructionsFile: string;
   instructionsAction: InstructionsAction;
   instructionsSnippet: string;
+  /** Whether any write would change state (false when the desired state is already present). */
+  changed: boolean;
 }
 
 export interface ClaudeInstallInput {
@@ -61,6 +63,10 @@ export interface ClaudeInstallInput {
   /** Current content of CLAUDE.md, or null if it does not exist. */
   claudeMdContent: string | null;
   existingSkillNames: string[];
+  /** Install skills without the PostToolUse hook (skills-only state). Default false. */
+  includeHook?: boolean;
+  /** Install skills without the marker-guarded CLAUDE.md reduce-pipe instruction. Default true. */
+  includeInstructions?: boolean;
 }
 
 interface HookEntry {
@@ -84,6 +90,8 @@ function hasHarnessTrimHook(settings: Record<string, unknown>): boolean {
  * present (idempotent).
  */
 export function planClaudeInstall(input: ClaudeInstallInput): ClaudeInstallPlan {
+  const includeHook = input.includeHook ?? true;
+  const includeInstructions = input.includeInstructions ?? true;
   const skillsDest = path.join(input.projectDir, ".claude", "skills");
   const existing = new Set(input.existingSkillNames);
   const skills: SkillCopy[] = input.skillNames.map((name) => ({
@@ -108,14 +116,22 @@ export function planClaudeInstall(input: ClaudeInstallInput): ClaudeInstallPlan 
     action = hasHarnessTrimHook(settings) ? "present" : "patch";
   }
 
+  // Skills-only install: never touch settings (the hook is the only settings write).
+  if (!includeHook) {
+    action = "present";
+    settings = input.settingsJsonContent === null ? {} : settings;
+  }
+
   const nextSettings = action === "present" ? settings : addHook(settings);
 
   const instructionsAction: InstructionsAction =
-    input.claudeMdContent === null
-      ? "create"
-      : input.claudeMdContent.includes(HARNESSTRIM_MARKER)
-        ? "present"
-        : "append";
+    !includeInstructions
+      ? "present"
+      : input.claudeMdContent === null
+        ? "create"
+        : input.claudeMdContent.includes(HARNESSTRIM_MARKER)
+          ? "present"
+          : "append";
 
   return {
     skillsDest,
@@ -126,6 +142,7 @@ export function planClaudeInstall(input: ClaudeInstallInput): ClaudeInstallPlan 
     instructionsFile: path.join(input.projectDir, "CLAUDE.md"),
     instructionsAction,
     instructionsSnippet: REDUCE_INSTRUCTION_SNIPPET,
+    changed: skills.some((s) => !s.present) || action !== "present" || instructionsAction !== "present",
   };
 }
 

--- a/packages/adapter-claude/src/install.ts
+++ b/packages/adapter-claude/src/install.ts
@@ -28,9 +28,9 @@ generated-file (lockfile/dist) diffs, and records what was saved. Prefer the ins
 for output, review, and scaffolding discipline.
 <!-- harnesstrim:end -->`;
 
-export type InstructionsAction = "create" | "append" | "present";
+export type InstructionsAction = "create" | "append" | "present" | "skip";
 
-export type SettingsAction = "create" | "patch" | "present";
+export type SettingsAction = "create" | "patch" | "present" | "skip";
 
 export interface SkillCopy {
   name: string;
@@ -118,15 +118,15 @@ export function planClaudeInstall(input: ClaudeInstallInput): ClaudeInstallPlan 
 
   // Skills-only install: never touch settings (the hook is the only settings write).
   if (!includeHook) {
-    action = "present";
+    action = "skip";
     settings = input.settingsJsonContent === null ? {} : settings;
   }
 
-  const nextSettings = action === "present" ? settings : addHook(settings);
+  const nextSettings = action === "present" || action === "skip" ? settings : addHook(settings);
 
   const instructionsAction: InstructionsAction =
     !includeInstructions
-      ? "present"
+      ? "skip"
       : input.claudeMdContent === null
         ? "create"
         : input.claudeMdContent.includes(HARNESSTRIM_MARKER)
@@ -142,7 +142,7 @@ export function planClaudeInstall(input: ClaudeInstallInput): ClaudeInstallPlan 
     instructionsFile: path.join(input.projectDir, "CLAUDE.md"),
     instructionsAction,
     instructionsSnippet: REDUCE_INSTRUCTION_SNIPPET,
-    changed: skills.some((s) => !s.present) || action !== "present" || instructionsAction !== "present",
+    changed: skills.some((s) => !s.present) || (action !== "present" && action !== "skip") || (instructionsAction !== "present" && instructionsAction !== "skip"),
   };
 }
 

--- a/packages/adapter-codex/src/index.test.ts
+++ b/packages/adapter-codex/src/index.test.ts
@@ -47,6 +47,22 @@ test("snippet documents the reduce pipe", () => {
   assert.match(plan.instructionsSnippet, /harnesstrim reduce/);
 });
 
+test("includeInstructions:false produces a skills-only state", () => {
+  const plan = planCodexInstall({ ...base, includeInstructions: false });
+  assert.equal(plan.instructionsAction, "present");
+});
+
+test("plan.changed is false when a skills-only install is already in that state", () => {
+  const first = planCodexInstall({ ...base, includeInstructions: false });
+  assert.equal(first.changed, true);
+  const rerun = planCodexInstall({
+    ...base,
+    includeInstructions: false,
+    existingSkillNames: base.skillNames,
+  });
+  assert.equal(rerun.changed, false);
+});
+
 test("plans an optional Codex Bash PostToolUse hook with telemetry", () => {
   const plan = planCodexHookInstall({ projectDir: "/proj", hooksJsonContent: null });
   assert.equal(plan.action, "create");

--- a/packages/adapter-codex/src/index.test.ts
+++ b/packages/adapter-codex/src/index.test.ts
@@ -49,7 +49,7 @@ test("snippet documents the reduce pipe", () => {
 
 test("includeInstructions:false produces a skills-only state", () => {
   const plan = planCodexInstall({ ...base, includeInstructions: false });
-  assert.equal(plan.instructionsAction, "present");
+  assert.equal(plan.instructionsAction, "skip");
 });
 
 test("plan.changed is false when a skills-only install is already in that state", () => {

--- a/packages/adapter-codex/src/index.ts
+++ b/packages/adapter-codex/src/index.ts
@@ -49,6 +49,8 @@ export interface CodexInstallPlan {
   instructionsFile: string;
   instructionsAction: InstructionsAction;
   instructionsSnippet: string;
+  /** Whether any write would change state (false when the desired state is already present). */
+  changed: boolean;
 }
 
 export interface CodexInstallInput {
@@ -61,6 +63,8 @@ export interface CodexInstallInput {
   agentsMdContent: string | null;
   /** Skill names already present at the destination. */
   existingSkillNames: string[];
+  /** Install skills without the AGENTS.md reduce-pipe instruction (skills-only). Default true. */
+  includeInstructions?: boolean;
 }
 
 interface HookEntry {
@@ -182,6 +186,7 @@ export function planCodexHookInstall(input: CodexHookInstallInput): CodexHookIns
  * the AGENTS.md snippet is added only if its marker is not already there (idempotent).
  */
 export function planCodexInstall(input: CodexInstallInput): CodexInstallPlan {
+  const includeInstructions = input.includeInstructions ?? true;
   const skillsDest = path.join(input.projectDir, ".codex", "skills");
   const existing = new Set(input.existingSkillNames);
   const skills: SkillCopy[] = input.skillNames.map((name) => ({
@@ -192,7 +197,9 @@ export function planCodexInstall(input: CodexInstallInput): CodexInstallPlan {
   }));
 
   let instructionsAction: InstructionsAction;
-  if (input.agentsMdContent === null) {
+  if (!includeInstructions) {
+    instructionsAction = "present";
+  } else if (input.agentsMdContent === null) {
     instructionsAction = "create";
   } else if (input.agentsMdContent.includes(HARNESSTRIM_MARKER)) {
     instructionsAction = "present";
@@ -206,5 +213,6 @@ export function planCodexInstall(input: CodexInstallInput): CodexInstallPlan {
     instructionsFile: path.join(input.projectDir, "AGENTS.md"),
     instructionsAction,
     instructionsSnippet: REDUCE_INSTRUCTION_SNIPPET,
+    changed: skills.some((s) => !s.present) || instructionsAction !== "present",
   };
 }

--- a/packages/adapter-codex/src/index.ts
+++ b/packages/adapter-codex/src/index.ts
@@ -33,7 +33,7 @@ generated-file (lockfile/dist) diffs. Prefer the installed skills for output, re
 scaffolding discipline.
 <!-- harnesstrim:end -->`;
 
-export type InstructionsAction = "create" | "append" | "present";
+export type InstructionsAction = "create" | "append" | "present" | "skip";
 
 export interface SkillCopy {
   name: string;
@@ -198,7 +198,7 @@ export function planCodexInstall(input: CodexInstallInput): CodexInstallPlan {
 
   let instructionsAction: InstructionsAction;
   if (!includeInstructions) {
-    instructionsAction = "present";
+    instructionsAction = "skip";
   } else if (input.agentsMdContent === null) {
     instructionsAction = "create";
   } else if (input.agentsMdContent.includes(HARNESSTRIM_MARKER)) {
@@ -213,6 +213,6 @@ export function planCodexInstall(input: CodexInstallInput): CodexInstallPlan {
     instructionsFile: path.join(input.projectDir, "AGENTS.md"),
     instructionsAction,
     instructionsSnippet: REDUCE_INSTRUCTION_SNIPPET,
-    changed: skills.some((s) => !s.present) || instructionsAction !== "present",
+    changed: skills.some((s) => !s.present) || (instructionsAction !== "present" && instructionsAction !== "skip"),
   };
 }

--- a/packages/adapter-hermes/plugin/__init__.py
+++ b/packages/adapter-hermes/plugin/__init__.py
@@ -225,14 +225,19 @@ def _write_metric(tool: str, reducer: str | None, before: int, after: int) -> No
     directory lazily and swallows any error — telemetry must never crash the plugin.
     """
     import datetime as _dt
+    import uuid as _uuid
 
     event = {
+        "schemaVersion": 1,
+        "eventId": str(_uuid.uuid4()),
         "ts": _dt.datetime.now(_dt.timezone.utc).isoformat(),
         "harness": "hermes",
         "tool": tool,
         "reducer": reducer,
         "beforeChars": before,
         "afterChars": after,
+        "beforeTokens": None,
+        "afterTokens": None,
     }
     try:
         METRICS_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/adapter-opencode/src/config.ts
+++ b/packages/adapter-opencode/src/config.ts
@@ -15,6 +15,8 @@ export interface AdapterConfig {
   debug: boolean;
   /** Inject compaction-handoff guidance on `experimental.session.compacting`. */
   compactionHandoff: boolean;
+  /** If set, only reduce outputs for these tool names (e.g. ["bash", "read"]). */
+  toolFilter: string[] | null;
   /** Append a TrimEvent JSONL record per reduction. Off by default (telemetry off by default). */
   telemetry: boolean;
   /** Where telemetry JSONL is appended (relative paths resolve against cwd). */
@@ -25,6 +27,22 @@ export const DEFAULT_TELEMETRY_PATH = ".harnesstrim/metrics.jsonl";
 
 function parseMode(value: unknown): Mode | undefined {
   return value === "active" || value === "dryrun" || value === "off" ? value : undefined;
+}
+
+/** Comma-separated string or array -> tool name list, or null when unset. */
+function parseToolFilter(value: unknown): string[] | null {
+  if (Array.isArray(value)) {
+    const names = value.filter((v): v is string => typeof v === "string" && v.length > 0);
+    return names.length > 0 ? names : null;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const names = value
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    return names.length > 0 ? names : null;
+  }
+  return null;
 }
 
 /**
@@ -43,6 +61,7 @@ export function resolveConfig(options: Record<string, unknown> = {}): AdapterCon
 
   const debug = options.debug === true || env.HARNESSTRIM_DEBUG === "1" || env.HARNESSTRIM_DEBUG === "true";
   const compactionHandoff = options.compactionHandoff !== false;
+  const toolFilter = parseToolFilter(options.toolFilter) ?? parseToolFilter(env.HARNESSTRIM_TOOLS);
 
   const telemetry =
     options.telemetry === true || env.HARNESSTRIM_TELEMETRY === "1" || env.HARNESSTRIM_TELEMETRY === "true";
@@ -51,5 +70,5 @@ export function resolveConfig(options: Record<string, unknown> = {}): AdapterCon
     env.HARNESSTRIM_TELEMETRY_PATH ??
     DEFAULT_TELEMETRY_PATH;
 
-  return { mode, minLength, debug, compactionHandoff, telemetry, telemetryPath };
+  return { mode, minLength, debug, compactionHandoff, toolFilter, telemetry, telemetryPath };
 }

--- a/packages/adapter-opencode/src/plugin.ts
+++ b/packages/adapter-opencode/src/plugin.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from "@opencode-ai/plugin";
-import { reduceAuto, type TrimEvent } from "@harnesstrim/core";
+import { reduceAuto, makeTrimEvent } from "@harnesstrim/core";
 import { resolveConfig } from "./config.ts";
 import { COMPACTION_HANDOFF_CONTEXT } from "./handoff.ts";
 import { createFileSink, noopSink } from "./telemetry.ts";
@@ -36,6 +36,9 @@ export const HarnessTrim: Plugin = async (_input, options) => {
   return {
     "tool.execute.after": async (input, output) => {
       if (typeof output.output !== "string") return;
+      // Per-surface selector: when the user installs for a subset of tool families,
+      // confine reduction to exactly those tools.
+      if (config.toolFilter && !config.toolFilter.includes(input.tool)) return;
       const result = reduceAuto(output.output, config.minLength);
       if (!result.changed) return;
 
@@ -45,15 +48,15 @@ export const HarnessTrim: Plugin = async (_input, options) => {
         output.output = result.output;
       }
 
-      const event: TrimEvent = {
-        ts: new Date().toISOString(),
-        harness: HARNESS,
-        tool: input.tool,
-        reducer: result.reducer,
-        beforeChars: before,
-        afterChars: after,
-      };
-      sink(event);
+      sink(
+        makeTrimEvent({
+          harness: HARNESS,
+          tool: input.tool,
+          reducer: result.reducer,
+          beforeChars: before,
+          afterChars: after,
+        })
+      );
       log(`${config.mode} ${input.tool} via ${result.reducer}: ${before} -> ${after} chars`);
     },
 

--- a/packages/adapter-pi/README.md
+++ b/packages/adapter-pi/README.md
@@ -12,6 +12,11 @@ The extension is **self-contained**: it shells out to `harnesstrim reduce` (no w
 it loads from any Pi extensions directory. `harnesstrim` must be on PATH; if it's missing the output
 passes through unchanged.
 
+> **Discovery note (Pi ≥ 0.82):** Pi's loader only discovers a *subdirectory* extension when it
+> contains `index.ts`/`index.js` or a `package.json` with a `pi.extensions` field. The installer
+> therefore ships the entry point as `harnesstrim/index.ts` (not `harnesstrim/harnesstrim.ts`), so the
+> extension is auto-loaded without settings registration.
+
 ## Install
 
 ```sh
@@ -34,8 +39,20 @@ Start in `dryrun`, watch for `[harnesstrim]` stderr lines, then set `HARNESSTRIM
 
 ## Status
 
-The install planner (`planPiInstall`) is pure and unit-tested; the extension ships with the package
-and is syntax-checked. The `tool_result` hook contract is confirmed against Pi's extension docs
-(events reference). **Not yet verified in a live Pi session** — the Pi CLI was not installed in the
-dev environment. To verify: `harnesstrim install pi --apply`, set `HARNESSTRIM_MODE=active`, run a
-command with noisy output in Pi, and confirm the model receives the slimmed version.
+Verified live on Pi 0.82.1 (2026-08-02), in both install scopes:
+
+- **Discovery fix:** Pi's loader (≥ 0.82) only auto-loads a *subdirectory* extension when it contains
+  `index.ts`/`index.js` or a `package.json` with a `pi.extensions` field. The installer ships the entry
+  point as `harnesstrim/index.ts`, which is picked up from `<project>/.pi/extensions/` and
+  `~/.pi/agent/extensions/` without settings registration. A second `--apply` refreshes the bundle and
+  prunes stale files from the installed dir.
+- **Dry-run:** with the default `HARNESSTRIM_MODE=dryrun`, the `tool_result` handler fires on `bash`
+  and `read` results and logs `[harnesstrim] dryrun tool_result: N -> M chars` to stderr without
+  changing anything.
+- **Active:** with `HARNESSTRIM_MODE=active`, text chunks are actually replaced — a 13902-char JSON
+  array reached the model as 6 lines (3 first + 3 last + `... omitted 74 items ...`) via
+  `json-output-slim`, and the model confirmed the omitted middle was genuinely absent.
+- **Failure safety:** with `harnesstrim` missing from PATH the output passes through unchanged; output
+  that already carries a `[harnesstrim` marker (already reduced) is never reduced twice.
+- Non-text chunks are left byte-for-byte untouched (unit-tested via `shouldSkip`; Pi's built-in tools
+  only emit text chunks, so this is not live-observable).

--- a/packages/adapter-pi/extension/index.ts
+++ b/packages/adapter-pi/extension/index.ts
@@ -29,6 +29,11 @@ const MODE = env.HARNESSTRIM_MODE ?? "dryrun";
 const MIN_LENGTH = Number(env.HARNESSTRIM_MINLENGTH ?? "400") || 400;
 const MARKER = "[harnesstrim";
 
+/** True when a text chunk should not be reduced: too short, or already reduced. */
+export function shouldSkip(text: string, minLength: number): boolean {
+  return text.length < minLength || text.includes(MARKER);
+}
+
 function reduceViaCli(text: string): string | null {
   try {
     const r = spawnSync("harnesstrim", ["reduce", "--min-length", String(MIN_LENGTH)], {
@@ -54,7 +59,7 @@ export default function harnesstrim(pi: ExtensionAPI): void {
     const content = event.content.map((chunk) => {
       if (chunk.type !== "text" || typeof chunk.text !== "string") return chunk;
       const text = chunk.text;
-      if (text.length < MIN_LENGTH || text.includes(MARKER)) return chunk;
+      if (shouldSkip(text, MIN_LENGTH)) return chunk;
 
       const reduced = reduceViaCli(text);
       if (!reduced || reduced.length >= text.length) return chunk;

--- a/packages/adapter-pi/src/extension.test.ts
+++ b/packages/adapter-pi/src/extension.test.ts
@@ -1,0 +1,20 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { shouldSkip } from "../extension/index.ts";
+
+test("shouldSkip passes through text below the min length", () => {
+  assert.equal(shouldSkip("short", 400), true);
+});
+
+test("shouldSkip never reduces already-reduced output (marker guard)", () => {
+  const reduced = "[harnesstrim:json-output-slim] array with 80 items\n{\"id\":0}";
+  assert.equal(shouldSkip(reduced, 0), true);
+});
+
+test("shouldSkip reduces long, marker-free text", () => {
+  assert.equal(shouldSkip("x".repeat(5000), 400), false);
+});
+
+test("shouldSkip at the exact min length boundary", () => {
+  assert.equal(shouldSkip("x".repeat(400), 400), false);
+});

--- a/packages/adapter-pi/src/index.ts
+++ b/packages/adapter-pi/src/index.ts
@@ -4,7 +4,7 @@ import path from "node:path";
  * HarnessTrim adapter for Pi (@earendil-works/pi-coding-agent).
  *
  * Pi loads TypeScript extensions from `~/.pi/agent/extensions/` (global) or
- * `<project>/.pi/extensions/` (project-local). Our extension (`extension/harnesstrim.ts`)
+ * `<project>/.pi/extensions/` (project-local). Our extension (`extension/index.ts`)
  * registers a `tool_result` handler that slims noisy tool output before it reaches the
  * model — Pi's deterministic tool-output hook, analogous to OpenCode's `tool.execute.after`.
  *

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harnesstrim",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "HarnessTrim CLI: doctor (diagnose token waste), install adapters, run benchmarks.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/smoke-test.sh
+++ b/packages/cli/smoke-test.sh
@@ -53,9 +53,18 @@ D="$PROJ/app"
 mkdir -p "$D"
 "$BIN" doctor "$D" >/dev/null 2>&1 || fail "doctor exited non-zero"
 
-# 5. reduce from stdin works and slims lint/test walls.
-REDUCED="$(printf 'a.js:1:2  warning  no-console - msg\nb.js:3:4  error  eqeqeq - msg\n\n✖ 1 warnings\n  1 errors\n' | "$BIN" reduce --metrics "$PROJ/m.jsonl" 2>/dev/null)" || fail "reduce exited non-zero"
+# 5. reduce from stdin works and slims lint/test walls. The lint wall must be
+#    longer than the 400-char default min-length or lint-output-slim is skipped.
+LINT_WALL="$(for i in $(seq 1 30); do printf "src/file%02d.js:%d:%d  warning  no-console - unused variable msg\n" "$i" "$((i+1))" "$((i*2))"; done)"
+LINT_WALL="$LINT_WALL
+✖ 30 warnings
+  0 errors"
+REDUCED="$(printf '%s\n' "$LINT_WALL" | "$BIN" reduce --metrics "$PROJ/m.jsonl" 2>/dev/null)" || fail "reduce exited non-zero"
 echo "$REDUCED" | grep -q "harnesstrim:lint-output-slim" || fail "reduce did not run lint-output-slim"
+# --min-length raises the threshold: a reducible input with a huge threshold passes through.
+REDUCED_HIGH="$(printf '%s\n' "$LINT_WALL" | "$BIN" reduce --min-length 999999 2>/dev/null)" || fail "reduce --min-length exited non-zero"
+echo "$REDUCED_HIGH" | grep -q "harnesstrim:lint-output-slim" && fail "reduce --min-length 999999 should not reduce"
+[ "$REDUCED_HIGH" = "$LINT_WALL" ] || fail "reduce --min-length 999999 changed the input"
 
 # 6. Every installer runs dry-run then --apply from a clean dir, using the
 #    shipped assets (skills / hermes plugin / pi extension).
@@ -72,6 +81,43 @@ done
 [ -d "$D/.hermes" ] || fail "hermes plugin not written"
 SKILLS="$("$BIN" preset list 2>/dev/null | head -1)" # sanity: presets resolve
 echo "== smoke: installers applied (opencode/codex/claude/hermes/pi), assets present =="
+
+# 6a. Narrowed installs write only what they promise.
+ND="$PROJ/narrowed"
+mkdir -p "$ND"
+"$BIN" install claude "$ND" --no-hook --apply >/dev/null 2>&1 || fail "install claude --no-hook --apply"
+[ -d "$ND/.claude/skills" ] || fail "--no-hook: skills missing"
+[ ! -f "$ND/.claude/settings.json" ] || fail "--no-hook: settings.json should NOT exist (hook skipped)"
+"$BIN" install codex "$ND" --no-instructions --apply >/dev/null 2>&1 || fail "install codex --no-instructions --apply"
+[ -d "$ND/.codex/skills" ] || fail "--no-instructions: codex skills missing"
+[ ! -f "$ND/AGENTS.md" ] || fail "--no-instructions: AGENTS.md should NOT exist"
+"$BIN" install opencode "$ND" --mode dryrun --min-length 2000 --tools bash,read --apply >/dev/null 2>&1 || fail "install opencode --mode/--min-length/--tools --apply"
+grep -q '"mode": "dryrun"' "$ND/.opencode/plugin/harnesstrim.ts" || fail "opencode wrapper missing mode dryrun"
+grep -q '"minLength": 2000' "$ND/.opencode/plugin/harnesstrim.ts" || fail "opencode wrapper missing minLength 2000"
+grep -q '"toolFilter"' "$ND/.opencode/plugin/harnesstrim.ts" || fail "opencode wrapper missing toolFilter"
+grep -q '"bash"' "$ND/.opencode/plugin/harnesstrim.ts" || fail "opencode wrapper missing bash in toolFilter"
+
+# 6b. capabilities is valid JSON and names all five harnesses.
+CAPS="$(node -e "JSON.parse(require('fs').readFileSync(0,'utf8'))" <<< "$("$BIN" capabilities 2>/dev/null)" && echo ok)" || fail "capabilities did not emit valid JSON"
+[ "$CAPS" = "ok" ] || fail "capabilities invalid JSON"
+for h in opencode codex claude hermes pi; do
+  "$BIN" capabilities 2>/dev/null | grep -q "\"$h\"" || fail "capabilities missing harness $h"
+done
+
+# 6c. --json works for doctor / install / metrics (one JSON object on stdout).
+node -e "JSON.parse(require('fs').readFileSync(0,'utf8'))" <<< "$("$BIN" doctor "$D" --json 2>/dev/null)" || fail "doctor --json invalid"
+node -e "JSON.parse(require('fs').readFileSync(0,'utf8'))" <<< "$("$BIN" install opencode "$ND" --json 2>/dev/null)" || fail "install --json invalid"
+
+# 6d. uninstall dry-runs, then --apply removes what install wrote.
+"$BIN" uninstall pi "$D" >/dev/null 2>&1 || fail "uninstall pi (dry-run)"
+[ -d "$D/.pi/extensions/harnesstrim" ] || fail "uninstall dry-run removed files without --apply"
+"$BIN" uninstall pi "$D" --apply >/dev/null 2>&1 || fail "uninstall pi --apply"
+[ -d "$D/.pi/extensions/harnesstrim" ] && fail "uninstall pi --apply left the extension dir"
+"$BIN" uninstall opencode "$D" --apply >/dev/null 2>&1 || fail "uninstall opencode --apply"
+[ -d "$D/.opencode/plugin" ] && fail "uninstall opencode --apply left the wrapper"
+"$BIN" uninstall claude "$D" --apply >/dev/null 2>&1 || fail "uninstall claude --apply"
+[ -d "$D/.claude/skills" ] && fail "uninstall claude --apply left skills"
+echo "== smoke: capabilities + --json + narrowing + uninstall verified =="
 
 # 7. mcp stdio handshake exposes the reduce tool.
 MCP_OUT="$(printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}\n' | timeout 10 "$BIN" mcp 2>/dev/null)" || fail "mcp initialize"

--- a/packages/cli/src/assets.ts
+++ b/packages/cli/src/assets.ts
@@ -34,7 +34,7 @@ export function resolveHermesPluginSourceDir(): string {
   return resolveAssetDir(path.join("adapter-hermes", "plugin"), path.join("packages", "adapter-hermes", "plugin"));
 }
 
-/** The shipped Pi extension bundle (harnesstrim.ts). */
+/** The shipped Pi extension bundle (index.ts, the entry Pi 0.82.1 auto-discovers). */
 export function resolvePiExtensionSourceDir(): string {
   return resolveAssetDir(path.join("adapter-pi", "extension"), path.join("packages", "adapter-pi", "extension"));
 }

--- a/packages/cli/src/capabilities.test.ts
+++ b/packages/cli/src/capabilities.test.ts
@@ -1,0 +1,85 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getCapabilities, CAPABILITIES } from "./capabilities.ts";
+import {
+  opencodeInstallJson,
+  claudeInstallJson,
+  codexInstallJson,
+  doctorJson,
+  metricsJson,
+} from "./json.ts";
+import { runInstallOpencode } from "./install.ts";
+import { runInstallClaude } from "./install-claude.ts";
+import { runInstallCodex } from "./install-codex.ts";
+import { inspect } from "./doctor.ts";
+import { loadMetrics } from "./metrics.ts";
+
+function tmpProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "htrim-json-"));
+}
+
+test("capabilities covers every supported harness and flags", () => {
+  const caps = getCapabilities("0.0.7");
+  assert.equal(caps.version, "0.0.7");
+  const names = Object.keys(caps.harnesses);
+  for (const h of ["opencode", "codex", "claude", "hermes", "pi"]) assert.ok(names.includes(h));
+  // the narrowing flags the plan requires are documented
+  assert.ok(CAPABILITIES.harnesses.claude.narrowing.some((n) => n.flag === "--no-hook"));
+  assert.ok(CAPABILITIES.harnesses.claude.narrowing.some((n) => n.flag === "--no-instructions"));
+  assert.ok(CAPABILITIES.harnesses.codex.narrowing.some((n) => n.flag === "--no-instructions"));
+  assert.ok(CAPABILITIES.harnesses.opencode.narrowing.some((n) => n.flag === "--mode active|dryrun|off"));
+  assert.ok(CAPABILITIES.harnesses.opencode.narrowing.some((n) => n.flag === "--tools <name,...>"));
+  // every harness documents its reviewed write set
+  for (const h of Object.values(caps.harnesses)) assert.ok(h.writeSet.length > 0);
+});
+
+test("doctorJson is valid JSON with the report shape", () => {
+  const dir = tmpProject();
+  fs.writeFileSync(path.join(dir, "CLAUDE.md"), "x".repeat(5000));
+  const parsed = JSON.parse(doctorJson(inspect(dir)));
+  assert.equal(parsed.dir, dir);
+  assert.ok(Array.isArray(parsed.findings));
+});
+
+test("metricsJson is valid JSON with the metrics shape", () => {
+  const dir = tmpProject();
+  const p = path.join(dir, "metrics.jsonl");
+  fs.writeFileSync(
+    p,
+    JSON.stringify({ schemaVersion: 1, eventId: "e1", ts: "t", harness: "opencode", tool: "bash", reducer: "x", beforeChars: 10, afterChars: 5, beforeTokens: null, afterTokens: null }) + "\n"
+  );
+  const parsed = JSON.parse(metricsJson(loadMetrics(p)));
+  assert.equal(parsed.found, true);
+  assert.equal(parsed.summary.events, 1);
+});
+
+test("opencodeInstallJson reports the plan as actions with paths", () => {
+  const dir = tmpProject();
+  const result = runInstallOpencode(dir, false);
+  const plan = opencodeInstallJson(result, false);
+  assert.equal(plan.harness, "opencode");
+  assert.equal(plan.dryRun, true);
+  assert.equal(plan.changed, true);
+  assert.ok(plan.actions.some((a) => a.type === "write" && a.path.endsWith(".opencode/plugin/harnesstrim.ts")));
+  assert.ok(plan.actions.some((a) => a.path.endsWith(".opencode/package.json")));
+});
+
+test("claudeInstallJson reflects a skills-only plan (no hook action)", () => {
+  const dir = tmpProject();
+  const result = runInstallClaude(dir, false, { includeHook: false });
+  const plan = claudeInstallJson(result, false);
+  assert.equal(plan.harness, "claude");
+  assert.ok(!plan.actions.some((a) => a.path.endsWith("settings.json")));
+  assert.ok(plan.actions.some((a) => a.type === "copy"));
+});
+
+test("codexInstallJson reflects a skills-only plan (no AGENTS.md action)", () => {
+  const dir = tmpProject();
+  const result = runInstallCodex(dir, false, false, { includeInstructions: false });
+  const plan = codexInstallJson(result, false);
+  assert.equal(plan.harness, "codex");
+  assert.ok(!plan.actions.some((a) => a.path.endsWith("AGENTS.md")));
+});

--- a/packages/cli/src/capabilities.test.ts
+++ b/packages/cli/src/capabilities.test.ts
@@ -63,8 +63,8 @@ test("opencodeInstallJson reports the plan as actions with paths", () => {
   assert.equal(plan.harness, "opencode");
   assert.equal(plan.dryRun, true);
   assert.equal(plan.changed, true);
-  assert.ok(plan.actions.some((a) => a.type === "write" && a.path.endsWith(".opencode/plugin/harnesstrim.ts")));
-  assert.ok(plan.actions.some((a) => a.path.endsWith(".opencode/package.json")));
+  assert.ok(plan.actions.some((a) => a.type === "write" && a.path.endsWith(path.join(".opencode", "plugin", "harnesstrim.ts"))));
+  assert.ok(plan.actions.some((a) => a.path.endsWith(path.join(".opencode", "package.json"))));
 });
 
 test("claudeInstallJson reflects a skills-only plan (no hook action)", () => {

--- a/packages/cli/src/capabilities.ts
+++ b/packages/cli/src/capabilities.ts
@@ -1,0 +1,97 @@
+/**
+ * Machine-readable capability table for `harnesstrim capabilities`.
+ *
+ * This is the single source of truth in the repo for what each supported harness's
+ * reduction + installer can do in THIS version. `capabilities` serializes it, so scripts,
+ * CI, and other consumers can discover and version-check support without hardcoding a
+ * per-version table anywhere. Update this file when a surface or an install flag changes.
+ */
+
+export interface CapabilityNarrowing {
+  /** The CLI flag that produces the narrower install state. */
+  flag: string;
+  /** What state the flag produces, e.g. "skills only, no hook". */
+  produces: string;
+}
+
+export interface HarnessCapabilities {
+  /** Adapter package this harness maps to. */
+  adapter: string;
+  /** Reduction surface(s) the adapter implements. */
+  surfaces: string[];
+  /** Narrower install states the installer can produce, and the flags that request them. */
+  narrowing: CapabilityNarrowing[];
+  /** The reviewed write set of `install <harness>` (paths relative to the install dir). */
+  writeSet: string[];
+}
+
+export interface Capabilities {
+  /** CLI version this table describes. */
+  version: string;
+  harnesses: Record<string, HarnessCapabilities>;
+}
+
+export const CAPABILITIES: Omit<Capabilities, "version"> = {
+  harnesses: {
+    opencode: {
+      adapter: "@harnesstrim/adapter-opencode",
+      surfaces: [
+        "tool.execute.after — slims noisy tool output in place before it enters context",
+        "experimental.session.compacting — injects compaction-handoff guidance",
+      ],
+      narrowing: [
+        { flag: "--mode active|dryrun|off", produces: "bake the reduction mode into the generated wrapper (active/dryrun/off)" },
+        { flag: "--min-length <n>", produces: "leave tool outputs shorter than n chars untouched (overrides preset)" },
+        { flag: "--tools <name,...>", produces: "confine reduction to a subset of tool families (e.g. bash,read)" },
+        { flag: "--preset <name>", produces: "bake a policy preset's adapter config into the wrapper" },
+      ],
+      writeSet: [
+        ".opencode/plugin/harnesstrim.ts",
+        ".opencode/package.json",
+        "opencode.json (cleans a stale adapter entry, never adds one)",
+      ],
+    },
+    codex: {
+      adapter: "@harnesstrim/adapter-codex",
+      surfaces: [
+        "PostToolUse Bash hook — deterministic reduction of simple Bash output (optional --hook)",
+        "AGENTS.md reduce-pipe instruction — model pipes noisy output through `harnesstrim reduce`",
+        "MCP reduce tool — deterministic, instruction-free reduction (separate `harnesstrim mcp`)",
+      ],
+      narrowing: [
+        { flag: "--no-instructions", produces: "skills only — no AGENTS.md reduce-pipe instruction" },
+        { flag: "--hook", produces: "also install the experimental Bash PostToolUse hook" },
+        { flag: "--global", produces: "install the hook once in ~/.codex (with --hook)" },
+      ],
+      writeSet: [".codex/skills/", "AGENTS.md (marker-guarded snippet)", ".codex/hooks.json (with --hook)"],
+    },
+    claude: {
+      adapter: "@harnesstrim/adapter-claude",
+      surfaces: [
+        "PostToolUse Bash hook — spec-correct updatedToolOutput (not honored by Claude Code 2.1.37–2.1.212)",
+        "CLAUDE.md reduce-pipe instruction — the effective reduction path on current Claude Code",
+      ],
+      narrowing: [
+        { flag: "--no-hook", produces: "skills only — no PostToolUse hook in .claude/settings.json" },
+        { flag: "--no-instructions", produces: "skills only — no CLAUDE.md reduce-pipe instruction" },
+      ],
+      writeSet: [".claude/skills/", ".claude/settings.json", "CLAUDE.md (marker-guarded snippet)"],
+    },
+    hermes: {
+      adapter: "@harnesstrim/adapter-hermes",
+      surfaces: ["transform_tool_result — deterministic reduction before the result enters context"],
+      narrowing: [],
+      writeSet: [".hermes/plugins/harnesstrim/ (incl. .installed marker)"],
+    },
+    pi: {
+      adapter: "@harnesstrim/adapter-pi",
+      surfaces: ["tool_result — deterministic reduction of text chunks in structured results"],
+      narrowing: [],
+      writeSet: [".pi/extensions/harnesstrim/ or .pi/agent/extensions/harnesstrim/ (incl. .installed marker)"],
+    },
+  },
+};
+
+export function getCapabilities(version: string): Capabilities {
+  return { version, ...CAPABILITIES };
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,7 +3,7 @@ import { parseArgs } from "node:util";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { getPreset, listPresets } from "@harnesstrim/core";
+import { getPreset, listPresets, makeTrimEvent } from "@harnesstrim/core";
 import { inspect } from "./doctor.ts";
 import { runInstallOpencode } from "./install.ts";
 import { runInstallCodex, runInstallCodexGlobalHook } from "./install-codex.ts";
@@ -16,6 +16,8 @@ import { loadMetrics, DEFAULT_METRICS_PATH } from "./metrics.ts";
 import pkg from "../package.json" with { type: "json" };
 
 import { readStdin, reducePipe } from "./reduce.ts";
+import { getCapabilities } from "./capabilities.ts";
+import { planUninstall, runUninstall } from "./uninstall.ts";
 import {
   renderDoctor,
   renderInstall,
@@ -27,7 +29,18 @@ import {
   renderMetrics,
   renderPresetList,
   renderPresetShow,
+  renderUninstall,
 } from "./render.ts";
+import {
+  doctorJson,
+  metricsJson,
+  opencodeInstallJson,
+  codexInstallJson,
+  claudeInstallJson,
+  hermesInstallJson,
+  piInstallJson,
+  codexGlobalHookJson,
+} from "./json.ts";
 
 const HELP = `harnesstrim — one token policy for coding harnesses
 
@@ -36,16 +49,25 @@ Usage:
   harnesstrim install opencode [dir]       Wire the adapter into opencode.json (dry-run)
                             --apply         Actually write the change
                             --preset <name> Bake a policy preset's adapter config in
+                            --mode <m>      Override mode: active|dryrun|off
+                            --min-length <n> Override the reduction threshold (chars)
+                            --tools <list>  Confine reduction to a subset of tool families
   harnesstrim install codex [dir]          Install skills + AGENTS.md reduction guidance (dry-run)
                             --apply         Actually write the change
                             --hook          Also install the experimental Bash PostToolUse hook
+                            --no-instructions  Skills only (no AGENTS.md reduce-pipe instruction)
                             --global        With --hook, install it once in ~/.codex (no project files)
   harnesstrim install claude [dir]         Install skills + PostToolUse reducer hook (dry-run)
                             --apply         Actually write the change
+                            --no-hook       Skills only (no PostToolUse hook)
+                            --no-instructions  Skills only (no CLAUDE.md reduce-pipe instruction)
   harnesstrim install hermes [dir]         Install Hermes plugin (dry-run)
                             --apply         Actually write the change
   harnesstrim install pi [dir]             Install Pi tool_result extension (dry-run)
                             --apply         Actually write the change
+  harnesstrim uninstall <harness> [dir]    Remove only what install wrote (dry-run)
+                            --apply         Actually write the change
+  harnesstrim capabilities                 Print machine-readable per-harness capabilities (JSON)
   harnesstrim hook claude [--metrics <path>]
                                            PostToolUse hook runtime; --metrics records a TrimEvent per reduction
   harnesstrim hook codex [--metrics <path>]
@@ -61,8 +83,11 @@ Usage:
   harnesstrim bench                        Run the Tier A reducer micro-benchmark
   harnesstrim --version                    Print the installed version
 
+Flags:
+  --json                                  Print machine-readable JSON (doctor, metrics, install, uninstall)
+
 Notes:
-  - install is dry-run by default; nothing is written without --apply.
+  - install and uninstall are dry-run by default; nothing is written without --apply.
   - dir defaults to the current directory; metrics path defaults to ${DEFAULT_METRICS_PATH}.
   - reduce reads stdin and writes slimmed output to stdout, e.g.  npm test 2>&1 | harnesstrim reduce`;
 
@@ -81,6 +106,11 @@ async function main(argv: string[]): Promise<number> {
       metrics: { type: "string" },
       hook: { type: "boolean" },
       global: { type: "boolean" },
+      "no-hook": { type: "boolean" },
+      "no-instructions": { type: "boolean" },
+      mode: { type: "string" },
+      tools: { type: "string" },
+      json: { type: "boolean" },
     },
   });
 
@@ -99,7 +129,12 @@ async function main(argv: string[]): Promise<number> {
   switch (command) {
     case "doctor": {
       const dir = rest[0] ?? process.cwd();
-      console.log(renderDoctor(inspect(dir)));
+      const report = inspect(dir);
+      if (values.json) {
+        console.log(doctorJson(report));
+      } else {
+        console.log(renderDoctor(report));
+      }
       return 0;
     }
     case "install": {
@@ -109,9 +144,22 @@ async function main(argv: string[]): Promise<number> {
       // project-local or alternate-profile installation.
       const dir = rest[1] ?? (target === "hermes" ? os.homedir() : process.cwd());
       const apply = values.apply === true;
+      const asJson = values.json === true;
       if (target === "opencode") {
-        const result = runInstallOpencode(dir, apply, values.preset);
-        console.log(renderInstall(result, apply));
+        const mode = parseModeFlag(values.mode);
+        if (mode === undefined && values.mode !== undefined) {
+          console.error(`Invalid --mode: ${values.mode} (expected active, dryrun, or off).`);
+          return 1;
+        }
+        const minLength = values["min-length"] !== undefined ? Number(values["min-length"]) : undefined;
+        if (minLength !== undefined && !Number.isFinite(minLength)) {
+          console.error(`Invalid --min-length: ${values["min-length"]}`);
+          return 1;
+        }
+        const tools = values.tools !== undefined ? splitTools(values.tools) : undefined;
+        const result = runInstallOpencode(dir, apply, values.preset, true, { mode, minLength, tools });
+        if (asJson) console.log(JSON.stringify(opencodeInstallJson(result, apply), null, 2));
+        else console.log(renderInstall(result, apply));
         return 0;
       }
       if (target === "codex") {
@@ -120,26 +168,62 @@ async function main(argv: string[]): Promise<number> {
             console.error("`harnesstrim install codex --global` requires `--hook`.");
             return 1;
           }
-          console.log(renderCodexGlobalHookInstall(runInstallCodexGlobalHook(path.join(os.homedir(), ".codex"), apply), apply));
+          const result = runInstallCodexGlobalHook(path.join(os.homedir(), ".codex"), apply);
+          if (asJson) console.log(JSON.stringify(codexGlobalHookJson(result, apply), null, 2));
+          else console.log(renderCodexGlobalHookInstall(result, apply));
           return 0;
         }
-        console.log(renderCodexInstall(runInstallCodex(dir, apply, values.hook === true), apply));
+        const result = runInstallCodex(dir, apply, values.hook === true, {
+          includeInstructions: values["no-instructions"] !== true,
+        });
+        if (asJson) console.log(JSON.stringify(codexInstallJson(result, apply), null, 2));
+        else console.log(renderCodexInstall(result, apply));
         return 0;
       }
       if (target === "claude") {
-        console.log(renderClaudeInstall(runInstallClaude(dir, apply), apply));
+        const result = runInstallClaude(dir, apply, {
+          includeHook: values["no-hook"] !== true,
+          includeInstructions: values["no-instructions"] !== true,
+        });
+        if (asJson) console.log(JSON.stringify(claudeInstallJson(result, apply), null, 2));
+        else console.log(renderClaudeInstall(result, apply));
         return 0;
       }
       if (target === "hermes") {
-        console.log(renderHermesInstall(runInstallHermes(dir, apply), apply));
+        const result = runInstallHermes(dir, apply);
+        if (asJson) console.log(JSON.stringify(hermesInstallJson(result, apply), null, 2));
+        else console.log(renderHermesInstall(result, apply));
         return 0;
       }
       if (target === "pi") {
-        console.log(renderPiInstall(runInstallPi(dir, apply), apply));
+        const result = runInstallPi(dir, apply);
+        if (asJson) console.log(JSON.stringify(piInstallJson(result, apply), null, 2));
+        else console.log(renderPiInstall(result, apply));
         return 0;
       }
       console.error(`Unknown install target: ${target ?? "(none)"}. Supported: opencode, codex, claude, hermes, pi.`);
       return 1;
+    }
+    case "uninstall": {
+      const target = rest[0];
+      const dir = rest[1] ?? (target === "hermes" ? os.homedir() : process.cwd());
+      const apply = values.apply === true;
+      try {
+        const result = runUninstall(target, dir, apply);
+        if (values.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(renderUninstall(result, apply));
+        }
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        return 1;
+      }
+      return 0;
+    }
+    case "capabilities": {
+      console.log(JSON.stringify(getCapabilities(pkg.version), null, 2));
+      return 0;
     }
     case "hook": {
       const which = rest[0];
@@ -157,7 +241,13 @@ async function main(argv: string[]): Promise<number> {
           fs.mkdirSync(path.dirname(p), { recursive: true });
           fs.appendFileSync(
             p,
-            JSON.stringify({ ts: new Date().toISOString(), harness: which, ...event }) + "\n"
+            JSON.stringify(
+              makeTrimEvent({
+                ts: new Date().toISOString(),
+                harness: which,
+                ...event,
+              })
+            ) + "\n"
           );
         } catch {
           /* telemetry must never break the hook */
@@ -197,7 +287,12 @@ async function main(argv: string[]): Promise<number> {
     }
     case "metrics": {
       const path = rest[0] ?? DEFAULT_METRICS_PATH;
-      console.log(renderMetrics(loadMetrics(path)));
+      const result = loadMetrics(path);
+      if (values.json) {
+        console.log(metricsJson(result));
+      } else {
+        console.log(renderMetrics(result));
+      }
       return 0;
     }
     case "reduce": {
@@ -217,14 +312,16 @@ async function main(argv: string[]): Promise<number> {
           fs.mkdirSync(path.dirname(p), { recursive: true });
           fs.appendFileSync(
             p,
-            JSON.stringify({
-              ts: new Date().toISOString(),
-              harness: "pipe",
-              tool: "reduce",
-              reducer: result.reducer,
-              beforeChars: result.beforeChars,
-              afterChars: result.afterChars,
-            }) + "\n"
+            JSON.stringify(
+              makeTrimEvent({
+                ts: new Date().toISOString(),
+                harness: "pipe",
+                tool: "reduce",
+                reducer: result.reducer,
+                beforeChars: result.beforeChars,
+                afterChars: result.afterChars,
+              })
+            ) + "\n"
           );
         } catch {
           /* telemetry must never break the pipe */
@@ -274,6 +371,19 @@ async function main(argv: string[]): Promise<number> {
       console.log(HELP);
       return 1;
   }
+}
+
+/** Parse `--mode` into the adapter's Mode union; undefined when unset or invalid. */
+function parseModeFlag(value: string | undefined): "active" | "dryrun" | "off" | undefined {
+  return value === "active" || value === "dryrun" || value === "off" ? value : undefined;
+}
+
+/** Split a comma-separated `--tools` value into trimmed tool names. */
+function splitTools(value: string): string[] {
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
 }
 
 main(process.argv.slice(2))

--- a/packages/cli/src/install-claude.ts
+++ b/packages/cli/src/install-claude.ts
@@ -61,7 +61,7 @@ export function runInstallClaude(dir: string, apply: boolean, options: ClaudeIns
       fs.cpSync(skill.from, skill.to, { recursive: true });
       copied.push(skill.name);
     }
-    if (plan.settingsAction !== "present") {
+    if (plan.settingsAction !== "present" && plan.settingsAction !== "skip") {
       fs.mkdirSync(path.dirname(plan.settingsFile), { recursive: true });
       fs.writeFileSync(plan.settingsFile, JSON.stringify(plan.nextSettings, null, 2) + "\n");
     }

--- a/packages/cli/src/install-claude.ts
+++ b/packages/cli/src/install-claude.ts
@@ -9,12 +9,19 @@ export interface ClaudeInstallResult {
   copied: string[];
 }
 
+export interface ClaudeInstallOptions {
+  /** Install skills without the PostToolUse hook (default true = hook included). */
+  includeHook?: boolean;
+  /** Install the CLAUDE.md reduce-pipe instruction (default true). */
+  includeInstructions?: boolean;
+}
+
 /**
  * Compute (and optionally apply) a Claude Code install: copy the shipped skill pack into
  * `<dir>/.claude/skills` and add a PostToolUse reducer hook to `.claude/settings.json`.
  * Dry-run by default; skills already present are skipped and the hook is added only once.
  */
-export function runInstallClaude(dir: string, apply: boolean): ClaudeInstallResult {
+export function runInstallClaude(dir: string, apply: boolean, options: ClaudeInstallOptions = {}): ClaudeInstallResult {
   const skillsSourceDir = resolveSkillsSourceDir();
   const skillNames = listShippedSkills(skillsSourceDir);
   const skillsDest = path.join(dir, ".claude", "skills");
@@ -42,11 +49,13 @@ export function runInstallClaude(dir: string, apply: boolean): ClaudeInstallResu
     settingsJsonContent,
     claudeMdContent,
     existingSkillNames: existingSkillNames(skillsDest),
+    includeHook: options.includeHook,
+    includeInstructions: options.includeInstructions,
   });
 
   const copied: string[] = [];
   let applied = false;
-  if (apply) {
+  if (apply && plan.changed) {
     for (const skill of plan.skills) {
       if (skill.present) continue;
       fs.cpSync(skill.from, skill.to, { recursive: true });

--- a/packages/cli/src/install-codex.ts
+++ b/packages/cli/src/install-codex.ts
@@ -44,13 +44,23 @@ function applyHookPlan(plan: CodexHookInstallPlan, apply: boolean): boolean {
   return true;
 }
 
+export interface CodexInstallOptions {
+  /** Install skills without the AGENTS.md reduce-pipe instruction (default true). */
+  includeInstructions?: boolean;
+}
+
 /**
  * Compute (and optionally apply) a Codex install: copy the shipped skill pack into
  * `<dir>/.codex/skills` and add the reduce-pipe instruction to AGENTS.md. Dry-run by
  * default; skills already present are skipped and the AGENTS.md snippet is only added
  * once (idempotent via its marker).
  */
-export function runInstallCodex(dir: string, apply: boolean, hook: boolean = false): CodexInstallResult {
+export function runInstallCodex(
+  dir: string,
+  apply: boolean,
+  hook: boolean = false,
+  options: CodexInstallOptions = {}
+): CodexInstallResult {
   const skillsSourceDir = resolveSkillsSourceDir();
   const skillNames = listShippedSkills(skillsSourceDir);
   const skillsDest = path.join(dir, ".codex", "skills");
@@ -69,6 +79,7 @@ export function runInstallCodex(dir: string, apply: boolean, hook: boolean = fal
     skillNames,
     agentsMdContent,
     existingSkillNames: existingSkillNames(skillsDest),
+    includeInstructions: options.includeInstructions,
   });
 
   const hooksPath = path.join(dir, ".codex", "hooks.json");
@@ -78,8 +89,9 @@ export function runInstallCodex(dir: string, apply: boolean, hook: boolean = fal
     : null;
 
   const copied: string[] = [];
+  const hookChanged = hookPlan !== null && hookPlan.action !== "present";
   let applied = false;
-  if (apply) {
+  if (apply && (plan.changed || hookChanged)) {
     for (const skill of plan.skills) {
       if (skill.present) continue;
       fs.cpSync(skill.from, skill.to, { recursive: true });
@@ -90,7 +102,7 @@ export function runInstallCodex(dir: string, apply: boolean, hook: boolean = fal
     } else if (plan.instructionsAction === "append") {
       fs.appendFileSync(plan.instructionsFile, "\n\n" + plan.instructionsSnippet + "\n");
     }
-    if (hookPlan) applyHookPlan(hookPlan, true);
+    if (hookPlan && hookChanged) applyHookPlan(hookPlan, true);
     applied = true;
   }
 

--- a/packages/cli/src/install-pi.test.ts
+++ b/packages/cli/src/install-pi.test.ts
@@ -8,11 +8,11 @@ import { runInstallPi } from "./install-pi.ts";
 test("runInstallPi --apply refreshes an existing project extension", () => {
   const project = fs.mkdtempSync(path.join(os.tmpdir(), "htrim-pi-install-"));
   const first = runInstallPi(project, true);
-  const extension = path.join(first.plan.extensionDest, "harnesstrim.ts");
+  const extension = path.join(first.plan.extensionDest, "index.ts");
   fs.writeFileSync(extension, "stale extension");
 
   const refreshed = runInstallPi(project, true);
 
   assert.equal(refreshed.applied, true);
-  assert.equal(fs.readFileSync(extension, "utf8"), fs.readFileSync(path.join(first.plan.extensionSource, "harnesstrim.ts"), "utf8"));
+  assert.equal(fs.readFileSync(extension, "utf8"), fs.readFileSync(path.join(first.plan.extensionSource, "index.ts"), "utf8"));
 });

--- a/packages/cli/src/install-pi.ts
+++ b/packages/cli/src/install-pi.ts
@@ -49,11 +49,19 @@ export function runInstallPi(installDir: string, apply: boolean): PiInstallResul
   let applied = false;
   if (apply) {
     fs.mkdirSync(dest, { recursive: true });
-    for (const entry of fs.readdirSync(extensionSourceDir, { withFileTypes: true })) {
-      if (!entry.isDirectory()) {
-        fs.copyFileSync(path.join(extensionSourceDir, entry.name), path.join(dest, entry.name));
-        copiedFiles.push(entry.name);
+    const sourceFiles = fs.readdirSync(extensionSourceDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name);
+    // Prune stale bundle files (e.g. a previous `harnesstrim.ts` entry) so the
+    // installed dir always mirrors the shipped bundle. Never touch `.installed`.
+    for (const existing of fs.readdirSync(dest)) {
+      if (existing !== ".installed" && !sourceFiles.includes(existing)) {
+        fs.rmSync(path.join(dest, existing), { recursive: true, force: true });
       }
+    }
+    for (const entry of sourceFiles) {
+      fs.copyFileSync(path.join(extensionSourceDir, entry), path.join(dest, entry));
+      copiedFiles.push(entry);
     }
     fs.writeFileSync(path.join(dest, ".installed"), markerFileContent());
     copiedFiles.push(".installed");

--- a/packages/cli/src/install.test.ts
+++ b/packages/cli/src/install.test.ts
@@ -136,3 +136,24 @@ test("runInstallOpencode throws on an unknown preset", () => {
   const dir = tmpProject();
   assert.throws(() => runInstallOpencode(dir, false, "nope"), /Unknown preset/);
 });
+
+test("runInstallOpencode overrides mode/min-length/tools via options", () => {
+  const dir = tmpProject();
+  const result = runInstallOpencode(dir, true, undefined, false, {
+    mode: "dryrun",
+    minLength: 500,
+    tools: ["bash", "read"],
+  });
+  const wrapper = fs.readFileSync(result.wrapperPath, "utf8");
+  assert.match(wrapper, /"mode": "dryrun"/);
+  assert.match(wrapper, /"minLength": 500/);
+  assert.match(wrapper, /"toolFilter": \[/);
+  assert.match(wrapper, /"bash"/);
+});
+
+test("runInstallOpencode options override a preset's adapter config", () => {
+  const dir = tmpProject();
+  const result = runInstallOpencode(dir, true, "lean-debug", false, { mode: "off" });
+  const wrapper = fs.readFileSync(result.wrapperPath, "utf8");
+  assert.match(wrapper, /"mode": "off"/);
+});

--- a/packages/cli/src/install.ts
+++ b/packages/cli/src/install.ts
@@ -150,17 +150,28 @@ export interface InstallResult extends OpencodeInstallPlan {
   preset?: Preset;
 }
 
+export interface OpencodeInstallOptions {
+  /** Override the baked-in reduction mode (`active` | `dryrun` | `off`). */
+  mode?: "active" | "dryrun" | "off";
+  /** Override the minimum output length (chars) below which output is left untouched. */
+  minLength?: number;
+  /** Confine reduction to this subset of tool families (e.g. ["bash", "read"]). */
+  tools?: string[];
+}
+
 /**
  * Compute (and optionally apply) the OpenCode install. Dry-run by default. Generates the
  * local wrapper + `.opencode/package.json`, cleans any adapter reference out of
  * opencode.json, and (on --apply) installs the `.opencode` dependency so the wrapper
- * resolves. A preset's adapter config is baked into the wrapper options.
+ * resolves. A preset's adapter config is baked into the wrapper options; explicit
+ * `options` (mode/minLength/tools) override the preset for that surface.
  */
 export function runInstallOpencode(
   dir: string,
   apply: boolean,
   presetName?: string,
   installDeps = true,
+  options: OpencodeInstallOptions = {},
 ): InstallResult {
   let preset: Preset | undefined;
   let adapterConfig = { ...DEFAULT_OPENCODE_ADAPTER_CONFIG };
@@ -169,6 +180,9 @@ export function runInstallOpencode(
     if (!preset) throw new Error(`Unknown preset: ${presetName}`);
     adapterConfig = { ...adapterConfig, ...preset.adapter };
   }
+  if (options.mode !== undefined) adapterConfig.mode = options.mode;
+  if (options.minLength !== undefined) adapterConfig.minLength = options.minLength;
+  if (options.tools !== undefined) adapterConfig.toolFilter = options.tools;
 
   const wrapperPath = path.join(dir, WRAPPER_REL);
   const packageJsonPath = path.join(dir, PKG_REL);

--- a/packages/cli/src/json.ts
+++ b/packages/cli/src/json.ts
@@ -1,0 +1,206 @@
+import type { DoctorReport } from "./doctor.ts";
+import type { MetricsResult } from "./metrics.ts";
+import type { InstallResult } from "./install.ts";
+import type { CodexGlobalHookInstallResult, CodexInstallResult } from "./install-codex.ts";
+import type { ClaudeInstallResult } from "./install-claude.ts";
+import type { PiInstallResult } from "./install-pi.ts";
+import type { HermesInstallResult } from "./install-hermes.ts";
+
+/**
+ * Machine-readable CLI output (the `--json` flag). Every command that accepts `--json`
+ * prints exactly ONE JSON object to stdout; human rendering stays the default.
+ * No JSON library is pulled in — `JSON.stringify` on plain data (zero runtime deps).
+ */
+
+export interface JsonAction {
+  type: "copy" | "write" | "append" | "clean" | "run" | "none";
+  /** Target path the action applies to (absolute). */
+  path: string;
+  /** Present only when the action is "copy". */
+  from?: string;
+  /** Human-readable note about the action (e.g. what would be written). */
+  note?: string;
+}
+
+export interface JsonInstallPlan {
+  harness: string;
+  dryRun: boolean;
+  changed: boolean;
+  alreadyInstalled: boolean;
+  applied: boolean;
+  actions: JsonAction[];
+  /** Extra per-harness facts (preset name, hook presence, ...). */
+  details?: Record<string, unknown>;
+}
+
+export function doctorJson(report: DoctorReport): string {
+  return JSON.stringify(report, null, 2);
+}
+
+export function metricsJson(result: MetricsResult): string {
+  return JSON.stringify(result, null, 2);
+}
+
+export function opencodeInstallJson(result: InstallResult, apply: boolean): JsonInstallPlan {
+  const actions: JsonAction[] = [];
+  if (result.changed) {
+    actions.push(
+      {
+        type: "write",
+        path: result.wrapperPath,
+        note: "local plugin wrapper with the adapter options",
+      },
+      {
+        type: "write",
+        path: result.packageJsonPath,
+        note: "declares @harnesstrim/adapter-opencode",
+      }
+    );
+    if (result.opencodeJsonContent !== null) {
+      actions.push({
+        type: "clean",
+        path: result.opencodeJsonPath,
+        note: "remove the stale adapter entry (options live in the wrapper now)",
+      });
+    }
+  }
+  return {
+    harness: "opencode",
+    dryRun: !apply,
+    changed: result.changed,
+    alreadyInstalled: result.alreadyInstalled,
+    applied: result.applied,
+    actions,
+    details: {
+      preset: result.preset?.name ?? null,
+      depsInstalled: result.depsInstalled,
+      depsMessage: result.depsMessage ?? null,
+    },
+  };
+}
+
+export function codexInstallJson(result: CodexInstallResult, apply: boolean): JsonInstallPlan {
+  const actions: JsonAction[] = result.plan.skills.map((s) => ({
+    type: s.present ? "none" : "copy",
+    path: s.to,
+    from: s.from,
+    note: s.present ? "already present" : "copy skill",
+  }));
+  if (result.plan.instructionsAction !== "present") {
+    actions.push({
+      type: result.plan.instructionsAction === "create" ? "write" : "append",
+      path: result.plan.instructionsFile,
+      note: `reduce-pipe instruction (${result.plan.instructionsAction})`,
+    });
+  }
+  if (result.hookPlan && result.hookPlan.action !== "present") {
+    actions.push({
+      type: "write",
+      path: result.hookPlan.hooksFile,
+      note: `Bash PostToolUse hook (${result.hookPlan.action})`,
+    });
+  }
+  const hookChanged = result.hookPlan !== null && result.hookPlan.action !== "present";
+  return {
+    harness: "codex",
+    dryRun: !apply,
+    changed: result.plan.changed || hookChanged,
+    alreadyInstalled: !result.plan.changed && !hookChanged,
+    applied: result.applied,
+    actions,
+    details: { hook: result.hookPlan ? result.hookPlan.action : "skipped" },
+  };
+}
+
+export function claudeInstallJson(result: ClaudeInstallResult, apply: boolean): JsonInstallPlan {
+  const actions: JsonAction[] = result.plan.skills.map((s) => ({
+    type: s.present ? "none" : "copy",
+    path: s.to,
+    from: s.from,
+    note: s.present ? "already present" : "copy skill",
+  }));
+  if (result.plan.settingsAction !== "present") {
+    actions.push({
+      type: result.plan.settingsAction === "create" ? "write" : "write",
+      path: result.plan.settingsFile,
+      note: `PostToolUse Bash hook (${result.plan.settingsAction})`,
+    });
+  }
+  if (result.plan.instructionsAction !== "present") {
+    actions.push({
+      type: result.plan.instructionsAction === "create" ? "write" : "append",
+      path: result.plan.instructionsFile,
+      note: `reduce-pipe instruction (${result.plan.instructionsAction})`,
+    });
+  }
+  return {
+    harness: "claude",
+    dryRun: !apply,
+    changed: result.plan.changed,
+    alreadyInstalled: !result.plan.changed,
+    applied: result.applied,
+    actions,
+    details: {
+      settingsAction: result.plan.settingsAction,
+      instructionsAction: result.plan.instructionsAction,
+    },
+  };
+}
+
+export function hermesInstallJson(result: HermesInstallResult, apply: boolean): JsonInstallPlan {
+  const actions: JsonAction[] = [
+    {
+      type: result.plan.alreadyInstalled ? "none" : "copy",
+      path: result.plan.pluginDest,
+      from: result.plan.pluginSource,
+      note: result.plan.alreadyInstalled ? "already installed" : "copy Hermes plugin bundle",
+    },
+  ];
+  return {
+    harness: "hermes",
+    dryRun: !apply,
+    changed: !result.plan.alreadyInstalled,
+    alreadyInstalled: result.plan.alreadyInstalled,
+    applied: result.applied,
+    actions,
+    details: { enabled: result.enabled, enableMessage: result.enableMessage ?? null },
+  };
+}
+
+export function piInstallJson(result: PiInstallResult, apply: boolean): JsonInstallPlan {
+  const actions: JsonAction[] = [
+    {
+      type: result.plan.alreadyInstalled ? "none" : "copy",
+      path: result.plan.extensionDest,
+      from: result.plan.extensionSource,
+      note: result.plan.alreadyInstalled ? "already installed" : "copy Pi extension bundle",
+    },
+  ];
+  return {
+    harness: "pi",
+    dryRun: !apply,
+    changed: !result.plan.alreadyInstalled,
+    alreadyInstalled: result.plan.alreadyInstalled,
+    applied: result.applied,
+    actions,
+  };
+}
+
+export function codexGlobalHookJson(result: CodexGlobalHookInstallResult, apply: boolean): JsonInstallPlan {
+  const actions: JsonAction[] = [
+    {
+      type: result.hookPlan.action === "present" ? "none" : "write",
+      path: result.hookPlan.hooksFile,
+      note: `global Bash PostToolUse hook (${result.hookPlan.action})`,
+    },
+  ];
+  return {
+    harness: "codex",
+    dryRun: !apply,
+    changed: result.hookPlan.action !== "present",
+    alreadyInstalled: result.hookPlan.action === "present",
+    applied: result.applied,
+    actions,
+    details: { scope: "global" },
+  };
+}

--- a/packages/cli/src/json.ts
+++ b/packages/cli/src/json.ts
@@ -86,7 +86,7 @@ export function codexInstallJson(result: CodexInstallResult, apply: boolean): Js
     from: s.from,
     note: s.present ? "already present" : "copy skill",
   }));
-  if (result.plan.instructionsAction !== "present") {
+  if (result.plan.instructionsAction !== "present" && result.plan.instructionsAction !== "skip") {
     actions.push({
       type: result.plan.instructionsAction === "create" ? "write" : "append",
       path: result.plan.instructionsFile,
@@ -119,14 +119,14 @@ export function claudeInstallJson(result: ClaudeInstallResult, apply: boolean): 
     from: s.from,
     note: s.present ? "already present" : "copy skill",
   }));
-  if (result.plan.settingsAction !== "present") {
+  if (result.plan.settingsAction !== "present" && result.plan.settingsAction !== "skip") {
     actions.push({
       type: result.plan.settingsAction === "create" ? "write" : "write",
       path: result.plan.settingsFile,
       note: `PostToolUse Bash hook (${result.plan.settingsAction})`,
     });
   }
-  if (result.plan.instructionsAction !== "present") {
+  if (result.plan.instructionsAction !== "present" && result.plan.instructionsAction !== "skip") {
     actions.push({
       type: result.plan.instructionsAction === "create" ? "write" : "append",
       path: result.plan.instructionsFile,

--- a/packages/cli/src/render.ts
+++ b/packages/cli/src/render.ts
@@ -117,11 +117,13 @@ export function renderCodexInstall(result: CodexInstallResult, apply: boolean): 
   lines.push("");
 
   const instr =
-    plan.instructionsAction === "present"
-      ? "AGENTS.md already contains the HarnessTrim instruction (no change)."
-      : plan.instructionsAction === "create"
-        ? `AGENTS.md ${apply ? "created" : "would be created"} with the reduce-pipe instruction.`
-        : `Reduce-pipe instruction ${apply ? "appended" : "would be appended"} to AGENTS.md.`;
+    plan.instructionsAction === "skip"
+      ? "AGENTS.md instruction skipped (--no-instructions); skills only."
+      : plan.instructionsAction === "present"
+        ? "AGENTS.md already contains the HarnessTrim instruction (no change)."
+        : plan.instructionsAction === "create"
+          ? `AGENTS.md ${apply ? "created" : "would be created"} with the reduce-pipe instruction.`
+          : `Reduce-pipe instruction ${apply ? "appended" : "would be appended"} to AGENTS.md.`;
   lines.push(instr);
 
   if (result.hookPlan) {
@@ -176,7 +178,9 @@ export function renderClaudeInstall(result: ClaudeInstallResult, apply: boolean)
   }
   lines.push("");
 
-  if (plan.settingsAction === "present") {
+  if (plan.settingsAction === "skip") {
+    lines.push(`${plan.settingsFile}: PostToolUse hook skipped (--no-hook); skills only.`);
+  } else if (plan.settingsAction === "present") {
     lines.push(`${plan.settingsFile}: PostToolUse reducer hook already present (no change).`);
   } else {
     lines.push(
@@ -189,7 +193,9 @@ export function renderClaudeInstall(result: ClaudeInstallResult, apply: boolean)
     }
   }
   lines.push("");
-  if (plan.instructionsAction === "present") {
+  if (plan.instructionsAction === "skip") {
+    lines.push(`${plan.instructionsFile}: reduce-pipe instruction skipped (--no-instructions); skills only.`);
+  } else if (plan.instructionsAction === "present") {
     lines.push(`${plan.instructionsFile}: reduce-pipe instruction already present (no change).`);
   } else {
     lines.push(
@@ -249,7 +255,7 @@ export function renderPiInstall(result: PiInstallResult, apply: boolean): string
       lines.push(`  Copied: ${result.copiedFiles.join(", ")}`);
     } else {
       lines.push(`  Source: ${plan.extensionSource}`);
-      lines.push("  (harnesstrim.ts + .installed marker)");
+      lines.push("  (index.ts + .installed marker)");
     }
     lines.push("");
     lines.push("The extension hooks Pi's `tool_result` and needs `harnesstrim` on PATH.");

--- a/packages/cli/src/render.ts
+++ b/packages/cli/src/render.ts
@@ -6,6 +6,7 @@ import type { CodexGlobalHookInstallResult, CodexInstallResult } from "./install
 import type { ClaudeInstallResult } from "./install-claude.ts";
 import type { PiInstallResult } from "./install-pi.ts";
 import type { HermesInstallResult } from "./install-hermes.ts";
+import type { UninstallResult } from "./uninstall.ts";
 
 const ICON: Record<Severity, string> = { warn: "!", info: "i", ok: "+" };
 
@@ -282,5 +283,35 @@ export function renderMetrics(result: MetricsResult): string {
     const p = b.beforeChars === 0 ? 0 : Math.round((b.savedChars / b.beforeChars) * 1000) / 10;
     lines.push(`  ${b.reducer.padEnd(20)} ${b.count}x  saved ${b.savedChars} chars (-${p}%)`);
   }
+  return lines.join("\n");
+}
+
+export function renderUninstall(result: UninstallResult, apply: boolean): string {
+  const lines: string[] = [`${apply ? "Uninstalled" : "Would uninstall"} ${result.harness} integration`, ""];
+  if (!result.changed) {
+    lines.push("Nothing to remove — no HarnessTrim files found in the install set.");
+    return lines.join("\n");
+  }
+  for (const action of result.actions) {
+    const verb =
+      action.type === "remove-file" || action.type === "remove-dir"
+        ? apply
+          ? "removed"
+          : "remove"
+        : action.type === "write"
+          ? apply
+            ? "updated"
+            : "update"
+          : "clean";
+    lines.push(`  ${verb.padEnd(8)} ${action.path}`);
+    if (action.note) lines.push(`             (${action.note})`);
+  }
+  if (!apply) {
+    lines.push("");
+    lines.push("Dry run — nothing written. Re-run with `--apply`.");
+  }
+  lines.push("");
+  lines.push("Only files HarnessTrim wrote are touched; marker-guarded regions and your");
+  lines.push("other settings/hook entries are preserved.");
   return lines.join("\n");
 }

--- a/packages/cli/src/uninstall.test.ts
+++ b/packages/cli/src/uninstall.test.ts
@@ -1,0 +1,124 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { planUninstall, runUninstall } from "./uninstall.ts";
+import { resolveSkillsSourceDir } from "./skills-source.ts";
+
+function tmpProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "htrim-uninstall-"));
+}
+
+function makeSkills(dest: string): string[] {
+  const sourceDir = resolveSkillsSourceDir();
+  const names = fs
+    .readdirSync(sourceDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+  fs.mkdirSync(dest, { recursive: true });
+  for (const name of names) {
+    fs.mkdirSync(path.join(dest, name), { recursive: true });
+    fs.writeFileSync(path.join(dest, name, "SKILL.md"), "---\nname: " + name + "\n---");
+  }
+  return names;
+}
+
+test("claude uninstall plans removing only HarnessTrim files", () => {
+  const dir = tmpProject();
+  const skills = makeSkills(path.join(dir, ".claude", "skills"));
+  fs.writeFileSync(
+    path.join(dir, ".claude", "settings.json"),
+    JSON.stringify({
+      model: "sonnet",
+      hooks: {
+        PostToolUse: [
+          { matcher: "Bash", hooks: [{ type: "command", command: "harnesstrim hook claude" }] },
+          { matcher: "Bash", hooks: [{ type: "command", command: "other hook" }] },
+        ],
+      },
+    })
+  );
+  fs.writeFileSync(path.join(dir, "CLAUDE.md"), "# Project\n<!-- harnesstrim:begin -->\n## Token economy\n<!-- harnesstrim:end -->\nKeep\n");
+
+  const plan = planUninstall("claude", dir);
+  assert.equal(plan.changed, true);
+  // one remove-dir per shipped skill + the now-empty parent skills dir
+  assert.equal(plan.actions.filter((a) => a.type === "remove-dir").length, skills.length + 1);
+  const settingsAction = plan.actions.find((a) => a.path.endsWith("settings.json"));
+  assert.equal(settingsAction?.type, "write"); // preserved model + other hook
+  const mdAction = plan.actions.find((a) => a.path.endsWith("CLAUDE.md"));
+  assert.equal(mdAction?.type, "write");
+});
+
+test("claude uninstall dry-run writes nothing; --apply removes only ours", () => {
+  const dir = tmpProject();
+  makeSkills(path.join(dir, ".claude", "skills"));
+  fs.writeFileSync(path.join(dir, ".claude", "settings.json"), JSON.stringify({ model: "sonnet", hooks: { PostToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "harnesstrim hook claude" }] }] } }));
+  fs.writeFileSync(path.join(dir, "CLAUDE.md"), "# Project\n<!-- harnesstrim:begin -->\n## Token economy (HarnessTrim)\n<!-- harnesstrim:end -->\n");
+
+  const dry = runUninstall("claude", dir, false);
+  assert.equal(dry.applied, false);
+  assert.ok(fs.existsSync(path.join(dir, ".claude", "skills")));
+
+  const applied = runUninstall("claude", dir, true);
+  assert.equal(applied.applied, true);
+  assert.equal(fs.existsSync(path.join(dir, ".claude", "skills")), false);
+  const settings = JSON.parse(fs.readFileSync(path.join(dir, ".claude", "settings.json"), "utf8"));
+  assert.equal(settings.model, "sonnet");
+  assert.equal(settings.hooks.PostToolUse.length, 0);
+  const md = fs.readFileSync(path.join(dir, "CLAUDE.md"), "utf8");
+  assert.match(md, /# Project/);
+  assert.ok(!md.includes("harnesstrim:begin"));
+});
+
+test("claude uninstall is a no-op when nothing was installed", () => {
+  const dir = tmpProject();
+  const plan = planUninstall("claude", dir);
+  assert.equal(plan.changed, false);
+});
+
+test("opencode uninstall removes the wrapper and drops the dependency", () => {
+  const dir = tmpProject();
+  const pluginDir = path.join(dir, ".opencode", "plugin");
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(path.join(pluginDir, "harnesstrim.ts"), "import { HarnessTrim } from \"@harnesstrim/adapter-opencode\";\nexport const HarnessTrimPlugin = (i) => HarnessTrim(i, {});");
+  fs.writeFileSync(
+    path.join(dir, ".opencode", "package.json"),
+    JSON.stringify({ dependencies: { "@harnesstrim/adapter-opencode": "^0.0.2", other: "1" } })
+  );
+
+  const plan = planUninstall("opencode", dir);
+  assert.equal(plan.changed, true);
+  const result = runUninstall("opencode", dir, true);
+  assert.equal(fs.existsSync(path.join(pluginDir, "harnesstrim.ts")), false);
+  const pkg = JSON.parse(fs.readFileSync(path.join(dir, ".opencode", "package.json"), "utf8"));
+  assert.equal(pkg.dependencies.other, "1");
+  assert.equal(pkg.dependencies["@harnesstrim/adapter-opencode"], undefined);
+  assert.equal(result.applied, true);
+});
+
+test("opencode uninstall removes package.json when it only declared the adapter", () => {
+  const dir = tmpProject();
+  fs.mkdirSync(path.join(dir, ".opencode", "plugin"), { recursive: true });
+  fs.writeFileSync(path.join(dir, ".opencode", "plugin", "harnesstrim.ts"), "import { HarnessTrim } from \"@harnesstrim/adapter-opencode\";");
+  fs.writeFileSync(path.join(dir, ".opencode", "package.json"), JSON.stringify({ dependencies: { "@harnesstrim/adapter-opencode": "^0.0.2" } }));
+  runUninstall("opencode", dir, true);
+  assert.equal(fs.existsSync(path.join(dir, ".opencode", "package.json")), false);
+});
+
+test("hermes uninstall removes the plugin dir only when the marker is present", () => {
+  const dir = tmpProject();
+  const pluginDest = path.join(dir, ".hermes", "plugins", "harnesstrim");
+  fs.mkdirSync(pluginDest, { recursive: true });
+  // no .installed marker → not considered ours
+  assert.equal(planUninstall("hermes", dir).changed, false);
+  fs.writeFileSync(path.join(pluginDest, ".installed"), "# harnesstrim:plugin-ready");
+  assert.equal(planUninstall("hermes", dir).changed, true);
+  runUninstall("hermes", dir, true);
+  assert.equal(fs.existsSync(pluginDest), false);
+});
+
+test("unknown uninstall target throws", () => {
+  assert.throws(() => planUninstall("nope", "/tmp"), /Unknown uninstall target/);
+});

--- a/packages/cli/src/uninstall.test.ts
+++ b/packages/cli/src/uninstall.test.ts
@@ -107,6 +107,27 @@ test("opencode uninstall removes package.json when it only declared the adapter"
   assert.equal(fs.existsSync(path.join(dir, ".opencode", "package.json")), false);
 });
 
+test("opencode uninstall removes a plugin dir that only contained our wrapper", () => {
+  const dir = tmpProject();
+  const pluginDir = path.join(dir, ".opencode", "plugin");
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(path.join(pluginDir, "harnesstrim.ts"), "import { HarnessTrim } from \"@harnesstrim/adapter-opencode\";");
+  runUninstall("opencode", dir, true);
+  assert.equal(fs.existsSync(pluginDir), false);
+});
+
+test("opencode uninstall leaves a plugin dir that holds a user file", () => {
+  const dir = tmpProject();
+  const pluginDir = path.join(dir, ".opencode", "plugin");
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(path.join(pluginDir, "harnesstrim.ts"), "import { HarnessTrim } from \"@harnesstrim/adapter-opencode\";");
+  fs.writeFileSync(path.join(pluginDir, "user-plugin.ts"), "export const p = {};");
+  runUninstall("opencode", dir, true);
+  assert.equal(fs.existsSync(path.join(pluginDir, "harnesstrim.ts")), false);
+  assert.equal(fs.existsSync(pluginDir), true);
+  assert.equal(fs.existsSync(path.join(pluginDir, "user-plugin.ts")), true);
+});
+
 test("hermes uninstall removes the plugin dir only when the marker is present", () => {
   const dir = tmpProject();
   const pluginDest = path.join(dir, ".hermes", "plugins", "harnesstrim");

--- a/packages/cli/src/uninstall.ts
+++ b/packages/cli/src/uninstall.ts
@@ -197,6 +197,15 @@ export function planOpencodeUninstall(dir: string): UninstallPlan {
   // Only remove the wrapper if it is ours (references the adapter package).
   if (wrapper !== null && wrapper.includes(OPENCODE_PLUGIN_NAME)) {
     actions.push({ type: "remove-file", path: wrapperPath, note: "HarnessTrim plugin wrapper" });
+    // If the plugin dir contains nothing but the wrapper we are removing, it was
+    // only ours — take it too.
+    const pluginDir = path.join(dir, ".opencode", "plugin");
+    if (fs.existsSync(pluginDir)) {
+      const entries = fs.readdirSync(pluginDir).filter((name) => name !== "harnesstrim.ts");
+      if (entries.length === 0) {
+        actions.push({ type: "remove-dir", path: pluginDir, note: "empty plugin directory left by HarnessTrim" });
+      }
+    }
   }
 
   const pkgPath = path.join(dir, ".opencode", "package.json");

--- a/packages/cli/src/uninstall.ts
+++ b/packages/cli/src/uninstall.ts
@@ -1,0 +1,322 @@
+import fs from "node:fs";
+import path from "node:path";
+import { HARNESSTRIM_MARKER as CLAUDE_MARKER } from "@harnesstrim/adapter-claude";
+import { HARNESSTRIM_MARKER as CODEX_MARKER } from "@harnesstrim/adapter-codex";
+import { OPENCODE_PLUGIN_NAME } from "./install.ts";
+import { listShippedSkills, resolveSkillsSourceDir } from "./skills-source.ts";
+
+/**
+ * `harnesstrim uninstall <harness>` — remove ONLY what `install <harness>` wrote.
+ * Dry-run by default (`--apply` to write). Never touches files the installer did not
+ * create and never removes content outside marker-guarded regions:
+ *  - claude: shipped skills, the hook entry in .claude/settings.json, the marker-guarded
+ *    CLAUDE.md snippet.
+ *  - codex: shipped skills, the marker-guarded AGENTS.md snippet, the hook in hooks.json.
+ *  - opencode: the wrapper + the .opencode/package.json dependency (removes package.json
+ *    when our dependency was its only content).
+ *  - hermes: the plugin dir (only when the .installed marker is present).
+ *  - pi: the extension dir (only when the .installed marker is present).
+ */
+
+export interface UninstallAction {
+  type: "remove-file" | "remove-dir" | "write" | "clean";
+  /** Absolute path this action targets. */
+  path: string;
+  /** Human-readable note on what would happen. */
+  note?: string;
+}
+
+export interface UninstallPlan {
+  harness: string;
+  dir: string;
+  changed: boolean;
+  actions: UninstallAction[];
+}
+
+export interface UninstallResult extends UninstallPlan {
+  applied: boolean;
+}
+
+function readOrNull(p: string): string | null {
+  try {
+    return fs.readFileSync(p, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/** Strip the marker-guarded region (`harnesstrim:begin` ... `harnesstrim:end`). */
+function stripMarkedRegion(content: string, marker: string): string | null {
+  const begin = `<!-- ${marker} -->`;
+  const end = "<!-- harnesstrim:end -->";
+  const start = content.indexOf(begin);
+  if (start === -1) return content;
+  const endIdx = content.indexOf(end, start);
+  if (endIdx === -1) return content;
+  const after = content.slice(endIdx + end.length);
+  const before = content.slice(0, start).replace(/\s+$/, "");
+  const next = (before + "\n" + after.replace(/^\s+/, "")).replace(/\n{3,}/g, "\n\n").trim();
+  return next;
+}
+
+/** Remove every PostToolUse hook entry whose command runs `harnesstrim hook`. */
+function stripHookEntries(settings: Record<string, unknown>): { next: Record<string, unknown>; removed: boolean } {
+  const hooks = settings.hooks as Record<string, unknown> | undefined;
+  if (!hooks || !Array.isArray(hooks.PostToolUse)) return { next: settings, removed: false };
+  const post = hooks.PostToolUse as unknown[];
+  const kept = post.filter((entry) => {
+    const hooksArr = (entry as { hooks?: Array<{ command?: string }> }).hooks;
+    if (!Array.isArray(hooksArr)) return true;
+    return !hooksArr.some((h) => typeof h.command === "string" && h.command.includes("harnesstrim hook"));
+  });
+  if (kept.length === post.length) return { next: settings, removed: false };
+  const nextHooks: Record<string, unknown> = { ...hooks };
+  nextHooks.PostToolUse = kept;
+  const next: Record<string, unknown> = { ...settings, hooks: nextHooks };
+  return { next, removed: true };
+}
+
+function isSkillDir(pathName: string): boolean {
+  try {
+    return fs.statSync(pathName).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function markerPresent(dest: string): boolean {
+  try {
+    return fs.statSync(path.join(dest, ".installed")).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Build the shared "remove shipped skills from dest" actions. */
+function skillRemovalActions(dir: string, destRel: string): UninstallAction[] {
+  const sourceDir = resolveSkillsSourceDir();
+  const shipped = listShippedSkills(sourceDir);
+  const dest = path.join(dir, destRel);
+  const actions: UninstallAction[] = [];
+  for (const name of shipped) {
+    const skillPath = path.join(dest, name);
+    if (isSkillDir(skillPath)) {
+      actions.push({ type: "remove-dir", path: skillPath, note: `skill directory installed by HarnessTrim` });
+    }
+  }
+  // If removing the shipped skills leaves only empty dirs behind, take the parent too —
+  // but never touch sibling entries that aren't ours.
+  if (actions.length > 0 && isSkillDir(dest)) {
+    const remaining = fs.readdirSync(dest).filter((name) => !shipped.includes(name));
+    if (remaining.length === 0) {
+      actions.push({ type: "remove-dir", path: dest, note: "empty skills directory left by HarnessTrim" });
+    }
+  }
+  return actions;
+}
+
+export function planClaudeUninstall(dir: string): UninstallPlan {
+  const actions: UninstallAction[] = [...skillRemovalActions(dir, ".claude/skills")];
+
+  const settingsPath = path.join(dir, ".claude", "settings.json");
+  const settingsContent = readOrNull(settingsPath);
+  if (settingsContent !== null) {
+    try {
+      const parsed = JSON.parse(settingsContent) as Record<string, unknown>;
+      const { next, removed } = stripHookEntries(parsed);
+      if (removed) {
+        actions.push({
+          type: Object.keys(next).length === 0 ? "remove-file" : "write",
+          path: settingsPath,
+          note: "remove the HarnessTrim PostToolUse hook",
+        });
+      }
+    } catch {
+      /* malformed settings: leave untouched (never clobber) */
+    }
+  }
+
+  const claudeMdPath = path.join(dir, "CLAUDE.md");
+  const claudeMd = readOrNull(claudeMdPath);
+  if (claudeMd !== null && claudeMd.includes(CLAUDE_MARKER)) {
+    const next = stripMarkedRegion(claudeMd, CLAUDE_MARKER);
+    if (next !== null && next !== claudeMd) {
+      actions.push({
+        type: next.length === 0 ? "remove-file" : "write",
+        path: claudeMdPath,
+        note: "remove the marker-guarded HarnessTrim instruction",
+      });
+    }
+  }
+
+  return { harness: "claude", dir, changed: actions.length > 0, actions };
+}
+
+export function planCodexUninstall(dir: string): UninstallPlan {
+  const actions: UninstallAction[] = [...skillRemovalActions(dir, ".codex/skills")];
+
+  const agentsPath = path.join(dir, "AGENTS.md");
+  const agents = readOrNull(agentsPath);
+  if (agents !== null && agents.includes(CODEX_MARKER)) {
+    const next = stripMarkedRegion(agents, CODEX_MARKER);
+    if (next !== null && next !== agents) {
+      actions.push({
+        type: next.length === 0 ? "remove-file" : "write",
+        path: agentsPath,
+        note: "remove the marker-guarded HarnessTrim instruction",
+      });
+    }
+  }
+
+  const hooksPath = path.join(dir, ".codex", "hooks.json");
+  const hooksContent = readOrNull(hooksPath);
+  if (hooksContent !== null) {
+    try {
+      const parsed = JSON.parse(hooksContent) as Record<string, unknown>;
+      const { next, removed } = stripHookEntries(parsed);
+      if (removed) {
+        actions.push({
+          type: Object.keys(next).length === 0 ? "remove-file" : "write",
+          path: hooksPath,
+          note: "remove the HarnessTrim PostToolUse hook",
+        });
+      }
+    } catch {
+      /* malformed hooks: leave untouched */
+    }
+  }
+
+  return { harness: "codex", dir, changed: actions.length > 0, actions };
+}
+
+export function planOpencodeUninstall(dir: string): UninstallPlan {
+  const actions: UninstallAction[] = [];
+
+  const wrapperPath = path.join(dir, ".opencode", "plugin", "harnesstrim.ts");
+  const wrapper = readOrNull(wrapperPath);
+  // Only remove the wrapper if it is ours (references the adapter package).
+  if (wrapper !== null && wrapper.includes(OPENCODE_PLUGIN_NAME)) {
+    actions.push({ type: "remove-file", path: wrapperPath, note: "HarnessTrim plugin wrapper" });
+  }
+
+  const pkgPath = path.join(dir, ".opencode", "package.json");
+  const pkgContent = readOrNull(pkgPath);
+  if (pkgContent !== null) {
+    try {
+      const parsed = JSON.parse(pkgContent) as Record<string, unknown>;
+      const deps = parsed.dependencies as Record<string, unknown> | undefined;
+      if (deps && typeof deps[OPENCODE_PLUGIN_NAME] === "string") {
+        const nextDeps: Record<string, unknown> = { ...deps };
+        delete nextDeps[OPENCODE_PLUGIN_NAME];
+        const next = { ...parsed, dependencies: nextDeps };
+        const onlyOurDep = Object.keys(nextDeps).length === 0 && Object.keys(parsed).length <= 1;
+        actions.push({
+          type: onlyOurDep ? "remove-file" : "write",
+          path: pkgPath,
+          note: onlyOurDep
+            ? "remove .opencode/package.json (only declared the adapter)"
+            : "drop the @harnesstrim/adapter-opencode dependency",
+        });
+      }
+    } catch {
+      /* malformed package.json: leave untouched */
+    }
+  }
+
+  return { harness: "opencode", dir, changed: actions.length > 0, actions };
+}
+
+export function planHermesUninstall(dir: string): UninstallPlan {
+  const pluginDest = path.join(dir, ".hermes", "plugins", "harnesstrim");
+  const actions: UninstallAction[] = [];
+  // Only a dir carrying our `.installed` marker is provably ours — never remove a
+  // same-named dir the user created independently.
+  if (markerPresent(pluginDest)) {
+    actions.push({ type: "remove-dir", path: pluginDest, note: "Hermes plugin installed by HarnessTrim" });
+  }
+  return { harness: "hermes", dir, changed: actions.length > 0, actions };
+}
+
+export function planPiUninstall(dir: string): UninstallPlan {
+  const scope = path.resolve(dir) === path.resolve(process.env.HOME ?? "") ? "user" : "project";
+  const dest =
+    scope === "user"
+      ? path.join(dir, ".pi", "agent", "extensions", "harnesstrim")
+      : path.join(dir, ".pi", "extensions", "harnesstrim");
+  const actions: UninstallAction[] = [];
+  if (markerPresent(dest)) {
+    actions.push({ type: "remove-dir", path: dest, note: "Pi extension installed by HarnessTrim" });
+  }
+  return { harness: "pi", dir, changed: actions.length > 0, actions };
+}
+
+export function planUninstall(harness: string, dir: string): UninstallPlan {
+  switch (harness) {
+    case "claude":
+      return planClaudeUninstall(dir);
+    case "codex":
+      return planCodexUninstall(dir);
+    case "opencode":
+      return planOpencodeUninstall(dir);
+    case "hermes":
+      return planHermesUninstall(dir);
+    case "pi":
+      return planPiUninstall(dir);
+    default:
+      throw new Error(`Unknown uninstall target: ${harness}. Supported: opencode, codex, claude, hermes, pi.`);
+  }
+}
+
+/** Apply an uninstall plan (destructive). Returns the resulting plan with applied=true. */
+export function runUninstall(harness: string, dir: string, apply: boolean): UninstallResult {
+  const plan = planUninstall(harness, dir);
+  if (!apply || !plan.changed) return { ...plan, applied: false };
+
+  for (const action of plan.actions) {
+    switch (action.type) {
+      case "remove-file":
+        fs.rmSync(action.path, { force: true });
+        break;
+      case "remove-dir":
+        fs.rmSync(action.path, { recursive: true, force: true });
+        break;
+      case "write": {
+        if (action.path.endsWith("settings.json") || action.path.endsWith("hooks.json")) {
+          const raw = readOrNull(action.path);
+          if (raw !== null) {
+            try {
+              const parsed = JSON.parse(raw) as Record<string, unknown>;
+              const { next } = stripHookEntries(parsed);
+              fs.writeFileSync(action.path, JSON.stringify(next, null, 2) + "\n");
+            } catch {
+              /* never clobber malformed JSON */
+            }
+          }
+        } else if (action.path.endsWith(path.join(".opencode", "package.json"))) {
+          const raw = readOrNull(action.path);
+          if (raw !== null) {
+            try {
+              const parsed = JSON.parse(raw) as Record<string, unknown>;
+              const deps = { ...((parsed.dependencies as Record<string, unknown>) ?? {}) };
+              delete deps[OPENCODE_PLUGIN_NAME];
+              fs.writeFileSync(action.path, JSON.stringify({ ...parsed, dependencies: deps }, null, 2) + "\n");
+            } catch {
+              /* never clobber malformed package.json */
+            }
+          }
+        } else {
+          const marker = action.path.endsWith("CLAUDE.md") ? CLAUDE_MARKER : CODEX_MARKER;
+          const raw = readOrNull(action.path);
+          if (raw !== null) {
+            const next = stripMarkedRegion(raw, marker);
+            if (next !== null) fs.writeFileSync(action.path, next + "\n");
+          }
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return { ...plan, applied: true };
+}

--- a/packages/core/src/metrics/trim-event.test.ts
+++ b/packages/core/src/metrics/trim-event.test.ts
@@ -1,12 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { summarize, parseTrimEvents, type TrimEvent } from "./trim-event.ts";
+import { summarize, parseTrimEvents, makeTrimEvent, type TrimEvent } from "./trim-event.ts";
 
 const events: TrimEvent[] = [
-  { ts: "t1", harness: "opencode", tool: "bash", reducer: "test-output-slim", beforeChars: 1000, afterChars: 400 },
-  { ts: "t2", harness: "opencode", tool: "bash", reducer: "git-diff-slim", beforeChars: 900, afterChars: 200 },
-  { ts: "t3", harness: "opencode", tool: "bash", reducer: "test-output-slim", beforeChars: 500, afterChars: 300 },
-  { ts: "t4", harness: "opencode", tool: "read", reducer: null, beforeChars: 100, afterChars: 100 },
+  makeTrimEvent({ ts: "t1", harness: "opencode", tool: "bash", reducer: "test-output-slim", beforeChars: 1000, afterChars: 400 }),
+  makeTrimEvent({ ts: "t2", harness: "opencode", tool: "bash", reducer: "git-diff-slim", beforeChars: 900, afterChars: 200 }),
+  makeTrimEvent({ ts: "t3", harness: "opencode", tool: "bash", reducer: "test-output-slim", beforeChars: 500, afterChars: 300 }),
+  makeTrimEvent({ ts: "t4", harness: "opencode", tool: "read", reducer: null, beforeChars: 100, afterChars: 100 }),
 ];
 
 test("summarize totals and percentage", () => {
@@ -55,4 +55,44 @@ test("parseTrimEvents accepts null reducer events", () => {
   const parsed = parseTrimEvents(JSON.stringify(events[3]));
   assert.equal(parsed.length, 1);
   assert.equal(parsed[0].reducer, null);
+});
+
+test("makeTrimEvent stamps the schema envelope (version 1, stable eventId, null tokens)", () => {
+  const e = makeTrimEvent({ harness: "opencode", tool: "bash", reducer: "x", beforeChars: 10, afterChars: 5 });
+  assert.equal(e.schemaVersion, 1);
+  assert.ok(e.eventId.length > 0);
+  assert.equal(e.beforeTokens, null);
+  assert.equal(e.afterTokens, null);
+  assert.ok(Number.isFinite(Date.parse(e.ts)));
+});
+
+test("makeTrimEvent carries token counts when the emitting path provides them", () => {
+  const e = makeTrimEvent({
+    harness: "opencode",
+    tool: "bash",
+    reducer: "x",
+    beforeChars: 10,
+    afterChars: 5,
+    beforeTokens: 8,
+    afterTokens: 4,
+  });
+  assert.equal(e.beforeTokens, 8);
+  assert.equal(e.afterTokens, 4);
+});
+
+test("parseTrimEvents normalizes legacy lines (no schema) to schemaVersion 0 and empty eventId", () => {
+  const legacy = JSON.stringify({
+    ts: "t1",
+    harness: "opencode",
+    tool: "bash",
+    reducer: "test-output-slim",
+    beforeChars: 1000,
+    afterChars: 400,
+  });
+  const parsed = parseTrimEvents(legacy);
+  assert.equal(parsed.length, 1);
+  assert.equal(parsed[0].schemaVersion, 0);
+  assert.equal(parsed[0].eventId, "");
+  assert.equal(parsed[0].beforeTokens, null);
+  assert.equal(parsed[0].afterChars, 400);
 });

--- a/packages/core/src/metrics/trim-event.ts
+++ b/packages/core/src/metrics/trim-event.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 /**
  * The normalized unit of HarnessTrim telemetry: one reduction the stack performed.
  *
@@ -6,8 +8,19 @@
  * HarnessTrim measures what HarnessTrim did. Values are in characters, matching what the
  * adapters measure at runtime (no tokenizer in the harness process). Parsing native
  * per-harness telemetry for vanilla-vs-trimmed comparison remains future work.
+ *
+ * Stream hardening (2026-08-01): every event carries `schemaVersion` (1) and a stable
+ * `eventId` so readers can version and dedupe the stream without synthesizing an ID.
+ * `beforeTokens`/`afterTokens` are token counts ONLY where the emitting path has them
+ * (`null` otherwise — no tokenizer is bundled into harness processes).
  */
+export const TRIM_EVENT_SCHEMA_VERSION = 1;
+
 export interface TrimEvent {
+  /** Stream schema version. Lines without it (legacy, pre-2026-08-01) parse as 0. */
+  schemaVersion: number;
+  /** Stable, per-event ID emitted by the producer (randomUUID). Empty for legacy lines. */
+  eventId: string;
   /** ISO timestamp, stamped by the emitter. */
   ts: string;
   /** Harness that produced the reduction, e.g. "opencode". */
@@ -18,6 +31,36 @@ export interface TrimEvent {
   reducer: string | null;
   beforeChars: number;
   afterChars: number;
+  /** Token count before reduction, only when the emitting path has one; else null. */
+  beforeTokens: number | null;
+  /** Token count after reduction, only when the emitting path has one; else null. */
+  afterTokens: number | null;
+}
+
+/**
+ * Build a fully-formed, schema-versioned TrimEvent. Producers should use this instead of
+ * hand-rolling the envelope so `schemaVersion`/`eventId` cannot drift between adapters.
+ * Token counts default to null (measured only where the emitting path has a tokenizer).
+ */
+export function makeTrimEvent(
+  partial: Omit<TrimEvent, "schemaVersion" | "eventId" | "ts" | "beforeTokens" | "afterTokens"> & {
+    ts?: string;
+    beforeTokens?: number | null;
+    afterTokens?: number | null;
+  }
+): TrimEvent {
+  return {
+    schemaVersion: TRIM_EVENT_SCHEMA_VERSION,
+    eventId: randomUUID(),
+    ts: partial.ts ?? new Date().toISOString(),
+    harness: partial.harness,
+    tool: partial.tool,
+    reducer: partial.reducer,
+    beforeChars: partial.beforeChars,
+    afterChars: partial.afterChars,
+    beforeTokens: partial.beforeTokens ?? null,
+    afterTokens: partial.afterTokens ?? null,
+  };
 }
 
 export interface ReducerBreakdown {
@@ -82,7 +125,9 @@ export function summarize(events: TrimEvent[]): TrimSummary {
 /**
  * Parse a JSONL telemetry stream into TrimEvents. Blank lines are skipped;
  * malformed lines are ignored (telemetry should never crash a read). Only lines
- * that structurally look like a TrimEvent are kept.
+ * that structurally look like a TrimEvent are kept. Legacy lines (pre-schema,
+ * without `schemaVersion`/`eventId`) are normalized to `schemaVersion: 0` and an
+ * empty `eventId`, so old streams keep reading.
  */
 export function parseTrimEvents(jsonl: string): TrimEvent[] {
   const out: TrimEvent[] = [];
@@ -95,7 +140,7 @@ export function parseTrimEvents(jsonl: string): TrimEvent[] {
     } catch {
       continue;
     }
-    if (isTrimEvent(parsed)) out.push(parsed);
+    if (isTrimEvent(parsed)) out.push(normalize(parsed));
   }
   return out;
 }
@@ -109,4 +154,20 @@ function isTrimEvent(value: unknown): value is TrimEvent {
     typeof v.tool === "string" &&
     (typeof v.reducer === "string" || v.reducer === null)
   );
+}
+
+/** Fill the schema envelope for lines that lack it (legacy streams), pass new lines through. */
+function normalize(v: TrimEvent): TrimEvent {
+  return {
+    schemaVersion: typeof v.schemaVersion === "number" ? v.schemaVersion : 0,
+    eventId: typeof v.eventId === "string" ? v.eventId : "",
+    ts: v.ts,
+    harness: v.harness,
+    tool: v.tool,
+    reducer: v.reducer,
+    beforeChars: v.beforeChars,
+    afterChars: v.afterChars,
+    beforeTokens: typeof v.beforeTokens === "number" ? v.beforeTokens : null,
+    afterTokens: typeof v.afterTokens === "number" ? v.afterTokens : null,
+  };
 }

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -4,7 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { reduceAuto, type TrimEvent } from "@harnesstrim/core";
+import { reduceAuto, makeTrimEvent, type TrimEvent } from "@harnesstrim/core";
 
 /** Records a reduction as a TrimEvent (or does nothing). */
 export type Sink = (event: TrimEvent) => void;
@@ -36,14 +36,15 @@ export function createFileSink(metricsPath: string): Sink {
 export function runReduceTool(text: string, minLength?: number, sink: Sink = noopSink): CallToolResult {
   const result = reduceAuto(text, minLength);
   if (result.changed) {
-    sink({
-      ts: new Date().toISOString(),
-      harness: "mcp",
-      tool: "reduce",
-      reducer: result.reducer,
-      beforeChars: text.length,
-      afterChars: result.output.length,
-    });
+    sink(
+      makeTrimEvent({
+        harness: "mcp",
+        tool: "reduce",
+        reducer: result.reducer,
+        beforeChars: text.length,
+        afterChars: result.output.length,
+      })
+    );
   }
   return { content: [{ type: "text", text: result.output }] };
 }


### PR DESCRIPTION
## harnesstrim 0.0.7 — Pi discovery fix, install precision, safe uninstall

Two commits on top of `origin/main` (`181d4a6`). `0.0.6` is already published on npm
(2026-08-01, from `de365e7`); this PR is the **0.0.7** release content.

### `122d05a` — install precision + machine-readable output + safe uninstall

- **Narrowed installs**: `install claude --no-hook` / `--no-instructions` and
  `install codex --no-instructions` do skills-only installs (planners honor
  `includeHook`/`includeInstructions`; nothing else is touched). `install opencode
  --mode active|dryrun|off`, `--min-length <n>`, and `--tools <name,...>` bake
  their overrides into the generated wrapper config.
- **Machine-readable output**: `doctor`, `install <harness>`, and `metrics` accept
  `--json`. `capabilities` prints a JSON table per harness: adapter surface,
  available narrowing flags, and the exact write-set each installer owns.
- **`uninstall <harness>`**: dry-run until `--apply`; only removes what HarnessTrim
  wrote — marker-guarded instruction regions, copied skill dirs, hook entries, and
  the OpenCode wrapper + package.json dependency.
- **TrimEvent schema**: `schemaVersion: 1` + stable `eventId`, legacy JSONL lines
  normalize.

### `58bc95a` — Pi discovery fix + skip-action honesty + extended smoke test

- **Pi 0.82.1 discovery fix**: Pi's loader only auto-discovers a *subdirectory*
  extension via `index.ts`/`index.js` or a `package.json` with a `pi.extensions`
  field — our installer wrote `harnesstrim/harnesstrim.ts`, which was silently
  ignored. Renamed the entry point to `harnesstrim/index.ts`, and `runInstallPi`
  now prunes stale bundle files on `--apply` so the installed dir always mirrors
  the shipped bundle. Verified live on Pi 0.82.1 (dryrun + active modes, both
  install scopes).
- **`"skip"` plan action**: narrowed installs (`--no-hook`/`--no-instructions`)
  previously reported `"present"`, rendering a false "already present (no change)".
  Added `"skip"` to Claude settings/instructions and Codex instructions; planners,
  runners, `render`, and `--json` all honor it.
- **`uninstall opencode`** now removes a plugin dir that contained only our
  wrapper (plan-time emptiness check was off by the wrapper file itself).
- **Extended smoke test** (`packages/cli/smoke-test.sh`): runs every installer from
  `npm pack` output — `--version`, zero runtime deps, all five installers apply
  with assets present, narrowing flags, `capabilities` JSON, `--json` on
  doctor/install/metrics, `--min-length` threshold semantics, and `uninstall`
  dry-run vs `--apply`.
- **Version bump**: `harnesstrim` → `0.0.7`.

**Verification**: 175 tests / 0 fail, typecheck clean on all packages, smoke test
green, Tier A bench fidelity OK.