### PR TITLE
docs(AGENTS): update published state to 0.0.7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,13 +40,13 @@ which is git-ignored — not in this file).
 
 ## Published state (as of last work)
 
-- `harnesstrim` published: latest 0.0.6 (2026-08-01). 0.0.7 in flight (open PR): Pi
-  discovery fix (`index.ts`), install-precision narrowing, `--json`/`capabilities`,
-  `uninstall`, TrimEvent schema, extended smoke test.
+- `harnesstrim` published: latest **0.0.7** (2026-08-02, PR #8 merged): Pi discovery fix
+  (`index.ts`), install-precision narrowing, `--json`/`capabilities`, `uninstall`,
+  TrimEvent schema, extended smoke test, AGENTS.md sanitized (machine info → AGENTS.local.md).
 - CLI features already present: `doctor`, `install opencode|codex|claude|hermes|pi`,
   `hook claude`, `reduce`, `mcp`, `bench`, `preset list/show`, `metrics`, `--version`,
   `capabilities`, `uninstall`, `--json` on doctor/install/metrics.
 - All five harness adapters exist (opencode/claude/codex/hermes/pi hooks; codex via
   instruction + MCP).
 - CI: `.github/workflows/ci.yml` (typecheck/test/bench on 3 OS + hermes plugin tests).
-  No release/publish job yet — planned.
+  No release/publish job yet — planned (next §9 v0.1.0 item).


### PR DESCRIPTION
Updates AGENTS.md Published state to reflect harnesstrim@0.0.7 (2026-08-02, PR #8 merged).