### PR TITLE
feat(metrics): add measurement depth and release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  quality:
+    name: quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Typecheck
+        run: pnpm run typecheck
+      - name: Test
+        run: pnpm run test
+      - name: Benchmark (fails if signal fidelity drops)
+        run: pnpm run bench
+      - name: Validate version/tag
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: node scripts/validate-release.mjs "$([ "$REF_TYPE" = "tag" ] && echo "$REF_NAME")"
+      - name: CLI build
+        run: node packages/cli/build.mjs
+      - name: Clean-package smoke test (npm pack -> fresh install)
+        run: bash packages/cli/smoke-test.sh
+
+  publish:
+    name: publish
+    needs: quality
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: "https://registry.npmjs.org"
+      - run: pnpm install --frozen-lockfile
+      - name: npm publish (harnesstrim)
+        working-directory: packages/cli
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Create GitHub release with notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="$(node -p "require('./packages/cli/package.json').version")"
+          gh release create "v$VERSION" --generate-notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,17 @@ which is git-ignored — not in this file).
 - `harnesstrim` published: latest **0.0.7** (2026-08-02, PR #8 merged): Pi discovery fix
   (`index.ts`), install-precision narrowing, `--json`/`capabilities`, `uninstall`,
   TrimEvent schema, extended smoke test, AGENTS.md sanitized (machine info → AGENTS.local.md).
+- **In progress (2026-08-03, not yet published):** v0.1.0 — `metrics` depth (per-harness /
+  pass-through rate / reduction-error counts, additive `changed` on TrimEvent), pass-through
+  telemetry on by default when telemetry is on (`HARNESSTRIM_TRACK_PASSTHROUGH=0|false` to opt out),
+  and the release pipeline (`.github/workflows/release.yml`: typecheck/test/bench/smoke +
+  version/tag validation via `scripts/validate-release.mjs`, then npm publish + auto release notes;
+  needs an `npm-publish` environment with `NPM_TOKEN`). CLI version bumped to **0.1.0**; publishing
+  is gated on an explicit tag push.
 - CLI features already present: `doctor`, `install opencode|codex|claude|hermes|pi`,
   `hook claude`, `reduce`, `mcp`, `bench`, `preset list/show`, `metrics`, `--version`,
   `capabilities`, `uninstall`, `--json` on doctor/install/metrics.
 - All five harness adapters exist (opencode/claude/codex/hermes/pi hooks; codex via
   instruction + MCP).
-- CI: `.github/workflows/ci.yml` (typecheck/test/bench on 3 OS + hermes plugin tests).
-  No release/publish job yet — planned (next §9 v0.1.0 item).
+- CI: `.github/workflows/ci.yml` (typecheck/test/bench on 3 OS + hermes plugin tests) and
+  `.github/workflows/release.yml` (tag-triggered publish pipeline, §9 v0.1.0).

--- a/PLAN.md
+++ b/PLAN.md
@@ -324,6 +324,27 @@ documented install path works from an empty directory.
 - Add release CI: typecheck, tests, Tier A fidelity benchmark, package smoke test, version/tag
   validation, npm publish, and generated release notes.
 
+**Status — 2026-08-03 (implemented, not yet released):**
+- `harnesstrim metrics` depth done: `summarize()` now reports per-harness breakdowns (`byHarness`),
+  attempt accounting (`reduced` / `passThrough` / `passThroughRate`) and reduction errors
+  (`reductionErrors` + `grewChars` — attempts recorded as changed that grew the output). TrimEvent
+  gained an additive `changed` field (default `true`; legacy lines normalize the same); the stream
+  schemaVersion stays 1.
+- Pass-through events are recorded by every emitter (OpenCode adapter, MCP `reduce`, `reduce` pipe,
+  Claude/Codex hooks) so the pass-through rate has a real denominator. On by default whenever
+  telemetry is on; opt out with `trackPassThrough: false` / `HARNESSTRIM_TRACK_PASSTHROUGH=0|false`.
+  Only char counts are recorded — never tool payloads. Hook adapters expose the attempted-but-
+  unchanged case via a new `attempt` field on `ClaudeReduction`/`CodexReduction`.
+- `lint-output-slim` (the §8 opportunity from the 2026-08-01 Tier B run) shipped earlier and is in
+  the bench: `lint/eslint-wall.txt` measures **−94.3% tokens at 100% signal recall**.
+- Release CI added (`.github/workflows/release.yml`): tag `v*` (or manual) → typecheck, test, Tier A
+  bench, version/tag validation (`scripts/validate-release.mjs`: tag must match
+  `packages/cli/package.json`, version must not exist on npm), CLI build + clean-package smoke test,
+  then npm publish (npm-publish environment, `NPM_TOKEN` secret) and a GitHub release with generated
+  notes.
+- 182 tests, typecheck clean, smoke green, Tier A bench fidelity OK. CLI version bumped to **0.1.0**;
+  publish is gated on an explicit tag push (user).
+
 **Exit criteria:** the release pipeline publishes a tested package; reducer additions are supported by
 telemetry and preserve benchmark signal recall.
 
@@ -350,6 +371,40 @@ savings for each supported integration path.
 multi-tool Tier B evidence are all repeatable.
 
 ## 10. Status log
+
+
+- **2026-08-03** — **v0.1.0 implemented (metrics depth + release CI), CLI bumped to 0.1.0, publish
+  still user-gated.** What landed:
+  - **`harnesstrim metrics` depth (the "trustworthy measurement" half).** `summarize()` now reports
+    `byHarness` (per-harness savings, sorted desc), attempt accounting (`reduced` / `passThrough` /
+    `passThroughRate`) and `reductionErrors` + `grewChars` for attempts marked changed that grew the
+    output. TrimEvent gained an additive, backward-compatible `changed` field (default `true`; legacy
+    schemaVersion-0 lines normalize to it, caveat: legacy events predate it and count as reduced).
+  - **Pass-through telemetry on by default when telemetry is on.** Every emitter — OpenCode
+    `tool.execute.after`, MCP `reduce`, the `reduce` pipe, and the Claude/Codex hooks — now records an
+    attempted-but-unchanged event (`reducer: null`, `changed: false`) for inputs over min-length, so
+    the pass-through rate has a true denominator (the evidence base for the "add reducers only for
+    repeated noisy-output classes" gate). Opt-out: `trackPassThrough: false` (OpenCode options) or
+    `HARNESSTRIM_TRACK_PASSTHROUGH=0|false` (env, respected by all paths). Char counts only — no tool
+    payloads, ever. Hook adapters gained an `attempt` field on `ClaudeReduction`/`CodexReduction`
+    (parseable payload, output ≥ minLength, nothing changed).
+  - **Release CI (`release.yml`).** Tag `v*` (or workflow_dispatch) → quality job (typecheck, full
+    test suite, Tier A bench fidelity gate, CLI build + the clean-package smoke test, and
+    `scripts/validate-release.mjs` which asserts tag = `packages/cli/package.json` version and that the
+    version is not already on npm) → publish job (`npm-publish` environment, `NPM_TOKEN` secret, npm
+    publish from `packages/cli`; `NODE_AUTH_TOKEN` used with registry-url) → `gh release create
+    --generate-notes`. Local validation verified: `v0.0.7` correctly rejected (already on npm),
+    `v0.1.0` accepted (publishable).
+  - `lint-output-slim` was already shipped (dispatch + fixture + tests); the bench confirms it on
+    `lint/eslint-wall.txt`: **−94.3% tokens, 5/5 must-keep, 0 dropped signal lines**. Tier A global:
+    −76.6% tokens, 100% recall, fidelity OK.
+  - Verification: **182 tests** (core 68, cli 49, adapter-opencode 12/other adapters green), typecheck
+    clean on all 9 packages, `packages/cli/smoke-test.sh` green on the `harnesstrim-0.1.0.tgz` tarball,
+    end-to-end pipe→metrics checked live (a 1200-char pass-through + a 488-char test run → render and
+    `--json` show per-harness/per-reducer splits, 50% pass-through). PLATE note on npm's 2FA: use the
+    2026-07-16 automation-token publish path.
+  - Remaining for release: `git push` a branch → PR → tag `v0.1.0` (as first released) and let the new
+    pipeline do the rest; the "npm-publish" environment needs `NPM_TOKEN` configured in the repo.
 
 
 - **2026-08-02** — **Pi adapter live-hardened and VERIFIED on Pi 0.82.1** (the last §9 v0.0.6

--- a/README.md
+++ b/README.md
@@ -343,8 +343,12 @@ pnpm exec harnesstrim bench                    # run the Tier A reducer micro-be
   available narrowing flags, and the exact write-set each installer owns.
 - `doctor`, `install`, and `metrics` accept `--json` for machine-readable output (scripts/CI).
 - `reduce` is the pipe-friendly reducer (RTK-style) shared across harnesses.
-- `metrics` aggregates the telemetry the adapter emits (off by default) into chars saved per reducer.
-  Lines carry a schema version and a stable event id.
+- `metrics` aggregates the telemetry the adapter emits (off by default) into totals with
+  **per-reducer** and **per-harness** splits, a **pass-through rate** (attempted-but-unchanged
+  output — the evidence base for adding reducers) and **reduction-error** counts (attempts that grew
+  the output). Pass-throughs are recorded whenever telemetry is on; opt out with
+  `HARNESSTRIM_TRACK_PASSTHROUGH=0`. Lines carry a schema version and a stable event id; only
+  character counts are recorded, never tool payloads.
 
 ## Try it
 

--- a/packages/adapter-claude/src/hook.ts
+++ b/packages/adapter-claude/src/hook.ts
@@ -1,4 +1,4 @@
-import { reduceAuto } from "@harnesstrim/core";
+import { reduceAuto, DEFAULT_MIN_LENGTH } from "@harnesstrim/core";
 
 /** What the Claude hook did: the response JSON to print, and (if it reduced) the facts for telemetry. */
 export interface ClaudeReduction {
@@ -10,6 +10,14 @@ export interface ClaudeReduction {
     reducer: string | null;
     beforeChars: number;
     afterChars: number;
+  } | null;
+  /**
+   * Set when the payload parsed and a reduction was ATTEMPTED (output >= min-length)
+   * but nothing changed — lets the hook record pass-through telemetry. Null otherwise.
+   */
+  attempt: {
+    tool: string;
+    beforeChars: number;
   } | null;
 }
 
@@ -24,10 +32,19 @@ export interface ClaudeReduction {
  */
 export function reduceClaudePayload(rawJson: string, minLength?: number): ClaudeReduction {
   const extracted = extractToolOutput(rawJson);
-  if (extracted === null) return { response: "{}", event: null };
+  if (extracted === null) return { response: "{}", event: null, attempt: null };
 
   const result = reduceAuto(extracted.output, minLength);
-  if (!result.changed) return { response: "{}", event: null };
+  if (!result.changed) {
+    return {
+      response: "{}",
+      event: null,
+      attempt:
+        extracted.output.length >= (minLength ?? DEFAULT_MIN_LENGTH)
+          ? { tool: extracted.toolName, beforeChars: extracted.output.length }
+          : null,
+    };
+  }
 
   const response = JSON.stringify({
     hookSpecificOutput: {
@@ -43,6 +60,7 @@ export function reduceClaudePayload(rawJson: string, minLength?: number): Claude
       beforeChars: extracted.output.length,
       afterChars: result.output.length,
     },
+    attempt: null,
   };
 }
 

--- a/packages/adapter-codex/src/hook.ts
+++ b/packages/adapter-codex/src/hook.ts
@@ -1,4 +1,4 @@
-import { reduceAuto } from "@harnesstrim/core";
+import { reduceAuto, DEFAULT_MIN_LENGTH } from "@harnesstrim/core";
 
 export interface CodexReduction {
   /** Hook-response JSON to write to stdout (`{}` leaves the result untouched). */
@@ -10,6 +10,14 @@ export interface CodexReduction {
     beforeChars: number;
     afterChars: number;
   } | null;
+  /**
+   * Set when the payload parsed and a reduction was ATTEMPTED (output >= min-length)
+   * but nothing changed — lets the hook record pass-through telemetry. Null otherwise.
+   */
+  attempt: {
+    tool: string;
+    beforeChars: number;
+  } | null;
 }
 
 /**
@@ -20,10 +28,19 @@ export interface CodexReduction {
  */
 export function reduceCodexPayload(rawJson: string, minLength?: number): CodexReduction {
   const extracted = extractToolOutput(rawJson);
-  if (extracted === null) return { response: "{}", event: null };
+  if (extracted === null) return { response: "{}", event: null, attempt: null };
 
   const result = reduceAuto(extracted.output, minLength);
-  if (!result.changed) return { response: "{}", event: null };
+  if (!result.changed) {
+    return {
+      response: "{}",
+      event: null,
+      attempt:
+        extracted.output.length >= (minLength ?? DEFAULT_MIN_LENGTH)
+          ? { tool: extracted.toolName, beforeChars: extracted.output.length }
+          : null,
+    };
+  }
 
   const response = JSON.stringify({
     decision: "block",
@@ -37,6 +54,7 @@ export function reduceCodexPayload(rawJson: string, minLength?: number): CodexRe
       beforeChars: extracted.output.length,
       afterChars: result.output.length,
     },
+    attempt: null,
   };
 }
 

--- a/packages/adapter-hermes/plugin/__init__.py
+++ b/packages/adapter-hermes/plugin/__init__.py
@@ -236,6 +236,7 @@ def _write_metric(tool: str, reducer: str | None, before: int, after: int) -> No
         "reducer": reducer,
         "beforeChars": before,
         "afterChars": after,
+        "changed": True,
         "beforeTokens": None,
         "afterTokens": None,
     }

--- a/packages/adapter-opencode/src/config.ts
+++ b/packages/adapter-opencode/src/config.ts
@@ -21,6 +21,12 @@ export interface AdapterConfig {
   telemetry: boolean;
   /** Where telemetry JSONL is appended (relative paths resolve against cwd). */
   telemetryPath: string;
+  /**
+   * Also record pass-through events (attempted reduction, nothing changed) so `metrics`
+   * can report a pass-through rate. On by default whenever telemetry is on; opt out
+   * with `trackPassThrough: false` or `HARNESSTRIM_TRACK_PASSTHROUGH=0|false`.
+   */
+  trackPassThrough: boolean;
 }
 
 export const DEFAULT_TELEMETRY_PATH = ".harnesstrim/metrics.jsonl";
@@ -70,5 +76,10 @@ export function resolveConfig(options: Record<string, unknown> = {}): AdapterCon
     env.HARNESSTRIM_TELEMETRY_PATH ??
     DEFAULT_TELEMETRY_PATH;
 
-  return { mode, minLength, debug, compactionHandoff, toolFilter, telemetry, telemetryPath };
+  const trackPassthroughEnv = env.HARNESSTRIM_TRACK_PASSTHROUGH;
+  const trackPassThrough =
+    options.trackPassThrough !== false &&
+    !(trackPassthroughEnv === "0" || trackPassthroughEnv === "false");
+
+  return { mode, minLength, debug, compactionHandoff, toolFilter, telemetry, telemetryPath, trackPassThrough };
 }

--- a/packages/adapter-opencode/src/plugin.test.ts
+++ b/packages/adapter-opencode/src/plugin.test.ts
@@ -102,3 +102,46 @@ test("telemetry: dryrun still records what would be reduced", async () => {
   const events = parseTrimEvents(fs.readFileSync(telemetryPath, "utf8"));
   assert.equal(events.length, 1); // but it recorded the potential reduction
 });
+
+test("telemetry: records a pass-through when tracking is on (default)", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "htrim-telemetry-"));
+  const telemetryPath = path.join(dir, "metrics.jsonl");
+  const hooks = await HarnessTrim(noopInput, { mode: "active", telemetry: true, telemetryPath });
+  const longNoMatch = "plain prose ".repeat(100); // > 400 chars, no reducer matches
+  const { input, output } = afterArgs(longNoMatch);
+  await hooks["tool.execute.after"]!(input, output);
+
+  assert.equal(output.output, longNoMatch);
+  const events = parseTrimEvents(fs.readFileSync(telemetryPath, "utf8"));
+  assert.equal(events.length, 1);
+  assert.equal(events[0].changed, false);
+  assert.equal(events[0].reducer, null);
+  assert.equal(events[0].beforeChars, longNoMatch.length);
+});
+
+test("telemetry: pass-through tracking can be opted out", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "htrim-telemetry-"));
+  const telemetryPath = path.join(dir, "metrics.jsonl");
+  const hooks = await HarnessTrim(noopInput, {
+    mode: "active",
+    telemetry: true,
+    telemetryPath,
+    trackPassThrough: false,
+  });
+  const longNoMatch = "plain prose ".repeat(100);
+  const { input, output } = afterArgs(longNoMatch);
+  await hooks["tool.execute.after"]!(input, output);
+
+  assert.equal(fs.existsSync(telemetryPath), false);
+});
+
+test("telemetry: sub-threshold output records no pass-through", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "htrim-telemetry-"));
+  const telemetryPath = path.join(dir, "metrics.jsonl");
+  const hooks = await HarnessTrim(noopInput, { mode: "active", telemetry: true, telemetryPath });
+  const short = "no structure here";
+  const { input, output } = afterArgs(short);
+  await hooks["tool.execute.after"]!(input, output);
+
+  assert.equal(fs.existsSync(telemetryPath), false);
+});

--- a/packages/adapter-opencode/src/plugin.ts
+++ b/packages/adapter-opencode/src/plugin.ts
@@ -40,24 +40,37 @@ export const HarnessTrim: Plugin = async (_input, options) => {
       // confine reduction to exactly those tools.
       if (config.toolFilter && !config.toolFilter.includes(input.tool)) return;
       const result = reduceAuto(output.output, config.minLength);
-      if (!result.changed) return;
-
       const before = output.output.length;
       const after = result.output.length;
-      if (config.mode === "active") {
-        output.output = result.output;
-      }
 
-      sink(
-        makeTrimEvent({
-          harness: HARNESS,
-          tool: input.tool,
-          reducer: result.reducer,
-          beforeChars: before,
-          afterChars: after,
-        })
-      );
-      log(`${config.mode} ${input.tool} via ${result.reducer}: ${before} -> ${after} chars`);
+      if (result.changed) {
+        if (config.mode === "active") {
+          output.output = result.output;
+        }
+        sink(
+          makeTrimEvent({
+            harness: HARNESS,
+            tool: input.tool,
+            reducer: result.reducer,
+            beforeChars: before,
+            afterChars: after,
+          })
+        );
+        log(`${config.mode} ${input.tool} via ${result.reducer}: ${before} -> ${after} chars`);
+      } else if (config.trackPassThrough && before >= config.minLength) {
+        // Attempted but nothing changed: record the pass-through so `metrics` can
+        // report the share of unreduced output (the evidence base for new reducers).
+        sink(
+          makeTrimEvent({
+            harness: HARNESS,
+            tool: input.tool,
+            reducer: null,
+            beforeChars: before,
+            afterChars: before,
+            changed: false,
+          })
+        );
+      }
     },
 
     "experimental.session.compacting": async (_compactInput, output) => {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harnesstrim",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "HarnessTrim CLI: doctor (diagnose token waste), install adapters, run benchmarks.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,7 +3,7 @@ import { parseArgs } from "node:util";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { getPreset, listPresets, makeTrimEvent } from "@harnesstrim/core";
+import { getPreset, listPresets, makeTrimEvent, DEFAULT_MIN_LENGTH } from "@harnesstrim/core";
 import { inspect } from "./doctor.ts";
 import { runInstallOpencode } from "./install.ts";
 import { runInstallCodex, runInstallCodexGlobalHook } from "./install-codex.ts";
@@ -232,23 +232,43 @@ async function main(argv: string[]): Promise<number> {
         return 1;
       }
       const input = await readStdin();
-      const { response, event } = which === "claude" ? reduceClaudePayload(input) : reduceCodexPayload(input);
+      const { response, event, attempt } =
+        which === "claude" ? reduceClaudePayload(input) : reduceCodexPayload(input);
       process.stdout.write(response);
       // --metrics <path>: append a TrimEvent per reduction, read by `harnesstrim metrics`.
-      if (values.metrics && event) {
+      // Pass-throughs (attempted but unchanged) are recorded too, per HARNESSTRIM_TRACK_PASSTHROUGH
+      // (default on), so the metrics pass-through rate is meaningful.
+      if (values.metrics) {
         try {
           const p = path.resolve(values.metrics);
           fs.mkdirSync(path.dirname(p), { recursive: true });
-          fs.appendFileSync(
-            p,
-            JSON.stringify(
-              makeTrimEvent({
-                ts: new Date().toISOString(),
-                harness: which,
-                ...event,
-              })
-            ) + "\n"
-          );
+          if (event) {
+            fs.appendFileSync(
+              p,
+              JSON.stringify(
+                makeTrimEvent({
+                  ts: new Date().toISOString(),
+                  harness: which,
+                  ...event,
+                })
+              ) + "\n"
+            );
+          } else if (attempt && trackPassThrough()) {
+            fs.appendFileSync(
+              p,
+              JSON.stringify(
+                makeTrimEvent({
+                  ts: new Date().toISOString(),
+                  harness: which,
+                  tool: attempt.tool,
+                  reducer: null,
+                  beforeChars: attempt.beforeChars,
+                  afterChars: attempt.beforeChars,
+                  changed: false,
+                })
+              ) + "\n"
+            );
+          }
         } catch {
           /* telemetry must never break the hook */
         }
@@ -306,23 +326,42 @@ async function main(argv: string[]): Promise<number> {
       const result = reducePipe(input, minLength);
       process.stdout.write(result.output);
       // --metrics <path>: append a TrimEvent per reduction, read by `harnesstrim metrics`.
-      if (values.metrics && result.changed) {
+      // Pass-throughs (attempted but unchanged) are recorded too, per HARNESSTRIM_TRACK_PASSTHROUGH
+      // (default on), so the metrics pass-through rate is meaningful.
+      if (values.metrics) {
         try {
           const p = path.resolve(values.metrics);
           fs.mkdirSync(path.dirname(p), { recursive: true });
-          fs.appendFileSync(
-            p,
-            JSON.stringify(
-              makeTrimEvent({
-                ts: new Date().toISOString(),
-                harness: "pipe",
-                tool: "reduce",
-                reducer: result.reducer,
-                beforeChars: result.beforeChars,
-                afterChars: result.afterChars,
-              })
-            ) + "\n"
-          );
+          if (result.changed) {
+            fs.appendFileSync(
+              p,
+              JSON.stringify(
+                makeTrimEvent({
+                  ts: new Date().toISOString(),
+                  harness: "pipe",
+                  tool: "reduce",
+                  reducer: result.reducer,
+                  beforeChars: result.beforeChars,
+                  afterChars: result.afterChars,
+                })
+              ) + "\n"
+            );
+          } else if (trackPassThrough() && input.length >= (minLength ?? DEFAULT_MIN_LENGTH)) {
+            fs.appendFileSync(
+              p,
+              JSON.stringify(
+                makeTrimEvent({
+                  ts: new Date().toISOString(),
+                  harness: "pipe",
+                  tool: "reduce",
+                  reducer: null,
+                  beforeChars: input.length,
+                  afterChars: input.length,
+                  changed: false,
+                })
+              ) + "\n"
+            );
+          }
         } catch {
           /* telemetry must never break the pipe */
         }
@@ -384,6 +423,15 @@ function splitTools(value: string): string[] {
     .split(",")
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
+}
+
+/**
+ * Whether pass-through (attempted-but-unchanged) events should be recorded alongside
+ * reductions. Reads HARNESSTRIM_TRACK_PASSTHROUGH; default on ("0" or "false" opts out).
+ */
+function trackPassThrough(): boolean {
+  const v = process.env.HARNESSTRIM_TRACK_PASSTHROUGH;
+  return v === undefined || (v !== "0" && v !== "false");
 }
 
 main(process.argv.slice(2))

--- a/packages/cli/src/metrics.test.ts
+++ b/packages/cli/src/metrics.test.ts
@@ -32,6 +32,39 @@ test("loadMetrics aggregates a JSONL file", () => {
   assert.equal(result.summary.events, 2);
   assert.equal(result.summary.savedChars, 1300);
   assert.equal(result.summary.byReducer.length, 2);
+  assert.equal(result.summary.byHarness.length, 1);
+  assert.equal(result.summary.byHarness[0].savedChars, 1300);
+});
+
+test("loadMetrics reports pass-through and per-harness splits", () => {
+  const p = tmpFile(
+    line({ ts: "t1", harness: "opencode", tool: "bash", reducer: "git-diff-slim", beforeChars: 900, afterChars: 200, changed: true }) +
+      "\n" +
+      line({ ts: "t2", harness: "claude", tool: "Bash", reducer: null, beforeChars: 800, afterChars: 800, changed: false }) +
+      "\n" +
+      line({ ts: "t3", harness: "claude", tool: "Bash", reducer: "test-output-slim", beforeChars: 600, afterChars: 300, changed: true }) +
+      "\n"
+  );
+  const result = loadMetrics(p);
+  assert.equal(result.summary.reduced, 2);
+  assert.equal(result.summary.passThrough, 1);
+  assert.equal(result.summary.passThroughRate, 33.3);
+  assert.equal(result.summary.reductionErrors, 0);
+assert.deepEqual(
+    result.summary.byHarness.map((h) => h.harness),
+    ["opencode", "claude"] // sorted by saved chars desc (opencode saved 700, claude 300)
+  );
+  assert.equal(result.summary.byHarness[0].savedChars, 700);
+});
+
+test("loadMetrics reports reduction errors when output grew", () => {
+  const p = tmpFile(
+    line({ harness: "pipe", tool: "reduce", reducer: "test-output-slim", beforeChars: 600, afterChars: 900, changed: true }) + "\n"
+  );
+  const result = loadMetrics(p);
+  assert.equal(result.summary.reductionErrors, 1);
+  assert.equal(result.summary.grewChars, 300);
+  assert.equal(result.summary.reduced, 0);
 });
 
 test("loadMetrics tolerates an empty file", () => {

--- a/packages/cli/src/render.ts
+++ b/packages/cli/src/render.ts
@@ -280,14 +280,27 @@ export function renderMetrics(result: MetricsResult): string {
   const lines = [
     `harnesstrim metrics — ${result.path}`,
     "",
-    `Reductions: ${s.events}`,
-    `Chars:      ${s.beforeChars} -> ${s.afterChars}  (saved ${s.savedChars}, -${s.reductionPct}%)`,
-    "",
-    "By reducer:",
+    `Attempts:     ${s.events} (${s.reduced} reduced, ${s.passThrough} pass-through, ${s.reductionErrors} error)`,
+    `Pass-through: ${s.passThroughRate}% of attempts unchanged`,
+    `Chars:        ${s.beforeChars} -> ${s.afterChars}  (saved ${s.savedChars}, -${s.reductionPct}%)`,
   ];
+  if (s.reductionErrors > 0) {
+    lines.push(`Reduction errors: ${s.reductionErrors} attempt(s) GREW the output (+${s.grewChars} chars) — investigate`);
+  }
+  lines.push("");
+  lines.push("By reducer:");
   for (const b of s.byReducer) {
     const p = b.beforeChars === 0 ? 0 : Math.round((b.savedChars / b.beforeChars) * 1000) / 10;
     lines.push(`  ${b.reducer.padEnd(20)} ${b.count}x  saved ${b.savedChars} chars (-${p}%)`);
+  }
+  if (s.byHarness.length > 0) {
+    lines.push("");
+    lines.push("By harness:");
+    for (const h of s.byHarness) {
+      const p = h.beforeChars === 0 ? 0 : Math.round((h.savedChars / h.beforeChars) * 1000) / 10;
+      const sign = p < 0 ? "" : "-";
+      lines.push(`  ${h.harness.padEnd(12)} ${h.count}x  saved ${h.savedChars} chars (${sign}${Math.abs(p)}%)`);
+    }
   }
   return lines.join("\n");
 }

--- a/packages/core/src/metrics/trim-event.test.ts
+++ b/packages/core/src/metrics/trim-event.test.ts
@@ -34,6 +34,29 @@ test("summarize handles empty input", () => {
   assert.equal(s.events, 0);
   assert.equal(s.reductionPct, 0);
   assert.deepEqual(s.byReducer, []);
+  assert.deepEqual(s.byHarness, []);
+  assert.equal(s.passThroughRate, 0);
+});
+
+test("summarize counts pass-throughs, errors, and per-harness totals", () => {
+  const s = summarize([
+    makeTrimEvent({ harness: "opencode", tool: "bash", reducer: "test-output-slim", beforeChars: 1000, afterChars: 300 }),
+    makeTrimEvent({ harness: "opencode", tool: "bash", reducer: null, beforeChars: 800, afterChars: 800, changed: false }),
+    makeTrimEvent({ harness: "claude", tool: "Bash", reducer: "git-diff-slim", beforeChars: 500, afterChars: 100 }),
+    makeTrimEvent({ harness: "pipe", tool: "reduce", reducer: null, beforeChars: 600, afterChars: 900, changed: true }),
+  ]);
+  assert.equal(s.events, 4);
+  assert.equal(s.reduced, 2);
+  assert.equal(s.passThrough, 1);
+  assert.equal(s.passThroughRate, 25);
+  assert.equal(s.reductionErrors, 1);
+  assert.equal(s.grewChars, 300);
+  assert.equal(s.byHarness.length, 3);
+  assert.equal(s.byHarness[0].harness, "opencode");
+  assert.equal(s.byHarness[0].count, 2);
+  assert.equal(s.byHarness[0].savedChars, 700);
+  assert.equal(s.byHarness[2].harness, "pipe");
+  assert.equal(s.byHarness[2].reductionPct, -50);
 });
 
 test("parseTrimEvents skips blank and malformed lines", () => {
@@ -63,7 +86,14 @@ test("makeTrimEvent stamps the schema envelope (version 1, stable eventId, null 
   assert.ok(e.eventId.length > 0);
   assert.equal(e.beforeTokens, null);
   assert.equal(e.afterTokens, null);
+  assert.equal(e.changed, true);
   assert.ok(Number.isFinite(Date.parse(e.ts)));
+});
+
+test("makeTrimEvent records a pass-through with changed: false", () => {
+  const e = makeTrimEvent({ harness: "opencode", tool: "bash", reducer: null, beforeChars: 50, afterChars: 50, changed: false });
+  assert.equal(e.changed, false);
+  assert.equal(e.reducer, null);
 });
 
 test("makeTrimEvent carries token counts when the emitting path provides them", () => {
@@ -95,4 +125,5 @@ test("parseTrimEvents normalizes legacy lines (no schema) to schemaVersion 0 and
   assert.equal(parsed[0].eventId, "");
   assert.equal(parsed[0].beforeTokens, null);
   assert.equal(parsed[0].afterChars, 400);
+  assert.equal(parsed[0].changed, true);
 });

--- a/packages/core/src/metrics/trim-event.ts
+++ b/packages/core/src/metrics/trim-event.ts
@@ -13,6 +13,11 @@ import { randomUUID } from "node:crypto";
  * `eventId` so readers can version and dedupe the stream without synthesizing an ID.
  * `beforeTokens`/`afterTokens` are token counts ONLY where the emitting path has them
  * (`null` otherwise — no tokenizer is bundled into harness processes).
+ *
+ * v0.1.0 (2026-08-03): additive `changed` field. `changed: false` marks a recorded
+ * pass-through (an attempted reduction that changed nothing) so `metrics` can report a
+ * pass-through rate — the denominator for deciding which noisy-output classes still need
+ * a reducer. Legacy lines without the field normalize to `changed: true`.
  */
 export const TRIM_EVENT_SCHEMA_VERSION = 1;
 
@@ -31,6 +36,8 @@ export interface TrimEvent {
   reducer: string | null;
   beforeChars: number;
   afterChars: number;
+  /** True when the attempt actually changed the output; false marks a recorded pass-through. */
+  changed: boolean;
   /** Token count before reduction, only when the emitting path has one; else null. */
   beforeTokens: number | null;
   /** Token count after reduction, only when the emitting path has one; else null. */
@@ -40,13 +47,15 @@ export interface TrimEvent {
 /**
  * Build a fully-formed, schema-versioned TrimEvent. Producers should use this instead of
  * hand-rolling the envelope so `schemaVersion`/`eventId` cannot drift between adapters.
- * Token counts default to null (measured only where the emitting path has a tokenizer).
+ * Token counts default to null (measured only where the emitting path has a tokenizer);
+ * `changed` defaults true (reduced) and is set false for recorded pass-throughs.
  */
 export function makeTrimEvent(
-  partial: Omit<TrimEvent, "schemaVersion" | "eventId" | "ts" | "beforeTokens" | "afterTokens"> & {
+  partial: Omit<TrimEvent, "schemaVersion" | "eventId" | "ts" | "beforeTokens" | "afterTokens" | "changed"> & {
     ts?: string;
     beforeTokens?: number | null;
     afterTokens?: number | null;
+    changed?: boolean;
   }
 ): TrimEvent {
   return {
@@ -58,6 +67,7 @@ export function makeTrimEvent(
     reducer: partial.reducer,
     beforeChars: partial.beforeChars,
     afterChars: partial.afterChars,
+    changed: partial.changed ?? true,
     beforeTokens: partial.beforeTokens ?? null,
     afterTokens: partial.afterTokens ?? null,
   };
@@ -71,7 +81,18 @@ export interface ReducerBreakdown {
   savedChars: number;
 }
 
+export interface HarnessBreakdown {
+  harness: string;
+  count: number;
+  beforeChars: number;
+  afterChars: number;
+  savedChars: number;
+  /** Percent reduction over that harness's events, one decimal place (negative when it grew). */
+  reductionPct: number;
+}
+
 export interface TrimSummary {
+  /** Total recorded attempts (reduced + pass-through + errors). */
   events: number;
   beforeChars: number;
   afterChars: number;
@@ -79,6 +100,18 @@ export interface TrimSummary {
   /** Percent reduction over all events, one decimal place. */
   reductionPct: number;
   byReducer: ReducerBreakdown[];
+  /** Per-harness totals, sorted by saved chars descending. */
+  byHarness: HarnessBreakdown[];
+  /** Attempts that actually shrank the output (changed: true and no growth). */
+  reduced: number;
+  /** Attempts that changed nothing (changed: false) — the pass-through denominator. */
+  passThrough: number;
+  /** Percent of recorded attempts that were pass-throughs, one decimal place. */
+  passThroughRate: number;
+  /** Attempts recorded as changed that GROW the output — reducer bugs worth fixing. */
+  reductionErrors: number;
+  /** Total growth in chars across reduction errors. */
+  grewChars: number;
 }
 
 function pct(before: number, after: number): number {
@@ -87,18 +120,43 @@ function pct(before: number, after: number): number {
 }
 
 /**
- * Aggregate a list of TrimEvents into totals and a per-reducer breakdown.
- * Pure and deterministic (independent of event timestamps). Events with a null
- * reducer contribute to totals but not to the per-reducer breakdown.
+ * Aggregate a list of TrimEvents into totals, a per-reducer breakdown, a per-harness
+ * breakdown, and attempt accounting (reduced vs pass-through vs errors). Pure and
+ * deterministic (independent of event timestamps). Events with a null reducer contribute
+ * to totals and the pass-through/error counts but not to the per-reducer breakdown.
  */
 export function summarize(events: TrimEvent[]): TrimSummary {
   let beforeChars = 0;
   let afterChars = 0;
+  let reduced = 0;
+  let passThrough = 0;
+  let reductionErrors = 0;
+  let grewChars = 0;
   const byReducerMap = new Map<string, ReducerBreakdown>();
+  const byHarnessMap = new Map<string, HarnessBreakdown>();
 
   for (const e of events) {
     beforeChars += e.beforeChars;
     afterChars += e.afterChars;
+    if (e.changed === false) {
+      passThrough++;
+    } else if (e.afterChars > e.beforeChars) {
+      reductionErrors++;
+      grewChars += e.afterChars - e.beforeChars;
+    } else {
+      reduced++;
+    }
+
+    const harness = e.harness ?? "unknown";
+    const h =
+      byHarnessMap.get(harness) ??
+      { harness, count: 0, beforeChars: 0, afterChars: 0, savedChars: 0, reductionPct: 0 };
+    h.count += 1;
+    h.beforeChars += e.beforeChars;
+    h.afterChars += e.afterChars;
+    h.savedChars += e.beforeChars - e.afterChars;
+    byHarnessMap.set(harness, h);
+
     if (e.reducer === null) continue;
     const b =
       byReducerMap.get(e.reducer) ??
@@ -111,6 +169,9 @@ export function summarize(events: TrimEvent[]): TrimSummary {
   }
 
   const byReducer = [...byReducerMap.values()].sort((a, b) => b.savedChars - a.savedChars);
+  const byHarness = [...byHarnessMap.values()]
+    .map((h) => ({ ...h, reductionPct: pct(h.beforeChars, h.afterChars) }))
+    .sort((a, b) => b.savedChars - a.savedChars);
 
   return {
     events: events.length,
@@ -119,6 +180,12 @@ export function summarize(events: TrimEvent[]): TrimSummary {
     savedChars: beforeChars - afterChars,
     reductionPct: pct(beforeChars, afterChars),
     byReducer,
+    byHarness,
+    reduced,
+    passThrough,
+    passThroughRate: events.length === 0 ? 0 : Math.round((passThrough / events.length) * 1000) / 10,
+    reductionErrors,
+    grewChars,
   };
 }
 
@@ -167,6 +234,7 @@ function normalize(v: TrimEvent): TrimEvent {
     reducer: v.reducer,
     beforeChars: v.beforeChars,
     afterChars: v.afterChars,
+    changed: typeof v.changed === "boolean" ? v.changed : true,
     beforeTokens: typeof v.beforeTokens === "number" ? v.beforeTokens : null,
     afterTokens: typeof v.afterTokens === "number" ? v.afterTokens : null,
   };

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -4,7 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { reduceAuto, makeTrimEvent, type TrimEvent } from "@harnesstrim/core";
+import { reduceAuto, makeTrimEvent, DEFAULT_MIN_LENGTH, type TrimEvent } from "@harnesstrim/core";
 
 /** Records a reduction as a TrimEvent (or does nothing). */
 export type Sink = (event: TrimEvent) => void;
@@ -31,10 +31,17 @@ export function createFileSink(metricsPath: string): Sink {
  * Pure logic behind the `reduce` MCP tool: slim `text` and return it as tool content.
  * Extracted so it can be unit-tested without an MCP transport. Deterministic and
  * idempotent (inherited from core.reduceAuto), and never grows the input. When a `sink`
- * is provided and a reduction happens, records one TrimEvent.
+ * is provided and a reduction happens, records one TrimEvent; with `trackPassThrough`
+ * (default true) it also records pass-through events for attempted-but-unchanged input.
  */
-export function runReduceTool(text: string, minLength?: number, sink: Sink = noopSink): CallToolResult {
+export function runReduceTool(
+  text: string,
+  minLength?: number,
+  sink: Sink = noopSink,
+  trackPassThrough = true
+): CallToolResult {
   const result = reduceAuto(text, minLength);
+  const threshold = minLength ?? DEFAULT_MIN_LENGTH;
   if (result.changed) {
     sink(
       makeTrimEvent({
@@ -43,6 +50,17 @@ export function runReduceTool(text: string, minLength?: number, sink: Sink = noo
         reducer: result.reducer,
         beforeChars: text.length,
         afterChars: result.output.length,
+      })
+    );
+  } else if (trackPassThrough && text.length >= threshold) {
+    sink(
+      makeTrimEvent({
+        harness: "mcp",
+        tool: "reduce",
+        reducer: null,
+        beforeChars: text.length,
+        afterChars: text.length,
+        changed: false,
       })
     );
   }
@@ -58,11 +76,14 @@ const REDUCE_DESCRIPTION =
 export interface ServerOptions {
   /** Append a TrimEvent JSONL record per reduction to this path (default: no telemetry). */
   metricsPath?: string;
+  /** Record pass-through events too (default true when metricsPath is set). */
+  trackPassThrough?: boolean;
 }
 
 /** Build the HarnessTrim MCP server with the `reduce` tool registered. */
 export function createServer(options: ServerOptions = {}): McpServer {
   const sink = options.metricsPath ? createFileSink(options.metricsPath) : noopSink;
+  const trackPassThrough = options.trackPassThrough !== false;
   const server = new McpServer({ name: "harnesstrim", version: "0.0.1" });
   server.registerTool(
     "reduce",
@@ -77,18 +98,22 @@ export function createServer(options: ServerOptions = {}): McpServer {
           .describe("Skip reduction for inputs shorter than this many characters (default 400)"),
       },
     },
-    async ({ text, minLength }) => runReduceTool(text, minLength, sink)
+    async ({ text, minLength }) => runReduceTool(text, minLength, sink, trackPassThrough)
   );
   return server;
 }
 
 /**
  * Start the server on stdio (used by `harnesstrim mcp`). Pass `metricsPath` (or set
- * `HARNESSTRIM_TELEMETRY_PATH`) to record a TrimEvent per reduction.
+ * `HARNESSTRIM_TELEMETRY_PATH`) to record a TrimEvent per reduction. Pass-through
+ * tracking follows `HARNESSTRIM_TRACK_PASSTHROUGH` (default on).
  */
 export async function startStdioServer(options: ServerOptions = {}): Promise<void> {
   const metricsPath = options.metricsPath ?? process.env.HARNESSTRIM_TELEMETRY_PATH;
-  const server = createServer({ metricsPath });
+  const envTrack = process.env.HARNESSTRIM_TRACK_PASSTHROUGH;
+  const trackPassThrough =
+    options.trackPassThrough ?? (envTrack !== undefined ? envTrack !== "0" && envTrack !== "false" : true);
+  const server = createServer({ metricsPath, trackPassThrough });
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Release pre-flight: verify a v* tag matches the published CLI version, and that the
+ * version is not already on npm. Called by .github/workflows/release.yml before the
+ * publish job. Exits non-zero on any mismatch so a bad tag can never publish.
+ *
+ * Usage: node scripts/validate-release.mjs [tag]
+ *   tag    The pushed tag (e.g. "v0.1.0"). Omitted for workflow_dispatch runs,
+ *          where only the npm-exists check applies.
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const cliPkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "packages/cli/package.json"), "utf8"));
+const version = cliPkg.version;
+const tag = process.argv[2];
+
+if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(version)) {
+  console.error(`FAIL: packages/cli/package.json version is not semver: ${version}`);
+  process.exit(1);
+}
+
+if (tag) {
+  const expected = `v${version}`;
+  if (!/^v\d+\.\d+\.\d+/.test(tag)) {
+    console.error(`FAIL: tag "${tag}" is not a vX.Y.Z tag`);
+    process.exit(1);
+  }
+  if (tag !== expected) {
+    console.error(`FAIL: tag "${tag}" does not match packages/cli/package.json version ${version} (expected "${expected}")`);
+    process.exit(1);
+  }
+  console.log(`OK: tag ${tag} matches package version ${version}`);
+} else {
+  console.log(`OK: no tag provided (manual run) — validating version ${version} against npm`);
+}
+
+let published = "";
+try {
+  published = execFileSync("npm", ["view", `harnesstrim@${version}`, "version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+} catch {
+  published = "";
+}
+if (published) {
+  console.error(`FAIL: harnesstrim@${version} is already published on npm`);
+  process.exit(1);
+}
+console.log(`OK: harnesstrim@${version} is not on npm yet — publishable`);


### PR DESCRIPTION
## Summary
- add per-harness metrics, pass-through/error accounting, and safe default pass-through telemetry
- record unchanged attempted reductions across OpenCode, Claude, Codex, MCP, and pipe paths
- add tag-gated release workflow with quality checks, npm preflight, publish, and generated release notes

## Verification
- npm run typecheck
- npm test
- npm run bench
- node scripts/validate-release.mjs v0.1.0
- node packages/cli/build.mjs && bash packages/cli/smoke-test.sh