### PR TITLE
feat: omp adapter, install config baking, capability digests, exact pipe/mcp token counts

### DIFF
--- a/packages/adapter-hermes/plugin/__init__.py
+++ b/packages/adapter-hermes/plugin/__init__.py
@@ -59,9 +59,29 @@ def register(ctx):
     ctx.register_hook("transform_tool_result", on_tool_result)
 
 
+def _load_file_config():
+    """Read the baked config from `config.json` beside the plugin (written by
+    `harnesstrim install hermes --mode/--min-length --apply`). Environment variables
+    still override it at runtime. Any malformed/missing file degrades to {}."""
+    cfg_path = PLUGIN_DIR / "config.json"
+    if not cfg_path.is_file():
+        return {}
+    try:
+        loaded = json.loads(cfg_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    return {key: loaded[key] for key in CONFIG_DEFAULTS if key in loaded}
+
+
 def _load_config():
-    """Return the active plugin config from the environment (no global registry needed)."""
+    """Return the active plugin config: env vars override the baked config.json
+    (from install), which overrides the built-in defaults. Keeps the runtime
+    override (HARNESSTRIM_MODE / HARNESSTRIM_MINLENGTH) winning, so an installed
+    state can always be switched without reinstalling."""
     cfg = dict(CONFIG_DEFAULTS)
+    cfg.update(_load_file_config())
     for key in CONFIG_DEFAULTS:
         env_key = f"HARNESSTRIM_{key.upper()}"
         val = os.environ.get(env_key)

--- a/packages/adapter-hermes/src/index.ts
+++ b/packages/adapter-hermes/src/index.ts
@@ -24,6 +24,47 @@ import path from "node:path";
 export const HERMES_PLUGIN_NAME = "harnesstrim";
 export const HERMES_PLUGIN_MARKER = "harnesstrim:plugin-ready";
 
+/**
+ * Config baked into `config.json` beside the plugin. The plugin reads env first
+ * (HARNESSTRIM_MODE / HARNESSTRIM_MINLENGTH still win at runtime — a user override
+ * beats the installed state), then this file, then its built-in defaults.
+ */
+export interface HermesAdapterConfig {
+  /** `active` reduces in place; `dryrun` logs only; `off` disables. */
+  mode: "active" | "dryrun" | "off";
+  /** Tool outputs shorter than this (chars) are left untouched. */
+  minLength: number;
+}
+
+/** The config `install hermes` writes when no options are given (plugin's own default). */
+export const DEFAULT_HERMES_ADAPTER_CONFIG: HermesAdapterConfig = { mode: "dryrun", minLength: 400 };
+
+/** True when the value looks like a known plugin mode. */
+export function isHermesMode(v: unknown): v is HermesAdapterConfig["mode"] {
+  return v === "active" || v === "dryrun" || v === "off";
+}
+
+/** Merge explicit overrides over an existing/parsed config, keeping the rest. */
+export function resolveHermesConfig(
+  existing: Partial<HermesAdapterConfig> | null,
+  overrides: { mode?: HermesAdapterConfig["mode"]; minLength?: number } = {}
+): HermesAdapterConfig {
+  const base = existing ?? DEFAULT_HERMES_ADAPTER_CONFIG;
+  return {
+    mode: overrides.mode ?? (isHermesMode(base.mode) ? base.mode : DEFAULT_HERMES_ADAPTER_CONFIG.mode),
+    minLength:
+      overrides.minLength ??
+      (typeof base.minLength === "number" && base.minLength > 0
+        ? base.minLength
+        : DEFAULT_HERMES_ADAPTER_CONFIG.minLength),
+  };
+}
+
+/** Deterministic, sorted-key JSON for the config file (also used for digests). */
+export function bakeHermesConfig(config: HermesAdapterConfig): string {
+  return JSON.stringify({ mode: config.mode, minLength: config.minLength }, null, 2) + "\n";
+}
+
 export interface SkillCopy {
   name: string;
   from: string;

--- a/packages/adapter-omp/hook/harnesstrim.ts
+++ b/packages/adapter-omp/hook/harnesstrim.ts
@@ -1,0 +1,162 @@
+// HarnessTrim OMP hook — slims noisy tool output via the `tool_result` hook.
+// Marker: harnesstrim:omp-hook
+//
+// omp auto-discovers default-export TS factories in ~/.omp/agent/hooks/post/*.ts
+// (global) and .omp/hooks/post/*.ts (project), loads them through its extension
+// runner, and fires `tool_result` after every successful tool call BEFORE the
+// result reaches the model. Returning `{ content }` replaces the result; returning
+// nothing leaves it untouched. Files in hooks/post/ are loaded with no trust gate
+// and no settings.json entry, so this hook's handlers bind on session start.
+//
+// This file is a hook FACTORY, not a harness process — it shells out to
+// `harnesstrim reduce` so the reducers live in the shared CLI core. Requires
+// `harnesstrim` on PATH; if missing or failing, output passes through unchanged
+// (a reducer must never break a tool result).
+//
+// Config precedence (highest first):
+//   1. Environment: HARNESSTRIM_MODE=dryrun|active|off, HARNESSTRIM_MINLENGTH=<chars>,
+//      HARNESSTRIM_METRICS=<path>
+//   2. config.json beside the hooks dir (written by `harnesstrim install omp --apply`
+//      with --mode/--min-length/--metrics)
+//   3. built-in defaults: dryrun, minLength 400.
+//
+// --metrics records a TrimEvent JSONL receipt per reduction (read by
+// `harnesstrim metrics`) — the receipt that makes interception verifiable.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const env = process.env;
+const MARKER = "[harnesstrim";
+const DEFAULT_MIN_LENGTH = 400;
+
+const HERE =
+  (typeof import.meta !== "undefined" && (import.meta as { dirname?: string }).dirname) || "";
+const CONFIG_PATH = HERE ? path.join(HERE, "..", "harnesstrim.json") : "";
+
+function readConfig(): { mode?: string; minLength?: number; metrics?: string } {
+  if (!CONFIG_PATH) return {};
+  try {
+    const parsed = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf8")) as Record<string, unknown>;
+    return {
+      mode: typeof parsed.mode === "string" ? parsed.mode : undefined,
+      minLength: typeof parsed.minLength === "number" ? parsed.minLength : undefined,
+      metrics: typeof parsed.metrics === "string" ? parsed.metrics : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
+const baked = readConfig();
+const MODE = env.HARNESSTRIM_MODE ?? baked.mode ?? "dryrun";
+const MIN_LENGTH = Number(env.HARNESSTRIM_MINLENGTH ?? (baked.minLength ?? DEFAULT_MIN_LENGTH)) || DEFAULT_MIN_LENGTH;
+const METRICS_PATH = env.HARNESSTRIM_METRICS || baked.metrics || undefined;
+
+interface TextChunk {
+  type: string;
+  text?: unknown;
+}
+
+function reduce(text: string): { output: string | null; reducer: string | null } {
+  try {
+    const r = spawnSync("harnesstrim", ["reduce", "--min-length", String(MIN_LENGTH), "--stats"], {
+      input: text,
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+    const stdout = typeof r.stdout === "string" ? r.stdout : "";
+    const stderr = typeof r.stderr === "string" ? r.stderr : "";
+    const output = stdout.replace(/\n$/, "");
+    if (r.status === 0 && output && output.length > 0) {
+      return { output, reducer: parseReducer(stderr) };
+    }
+  } catch {
+    /* harnesstrim not on PATH or failed — pass through */
+  }
+  return { output: null, reducer: null };
+}
+
+function parseReducer(stderr: string): string | null {
+  for (const line of stderr.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("[harnesstrim reduce]")) {
+      const rest = trimmed.slice("[harnesstrim reduce] ".length);
+      if (rest.includes(":") && !rest.includes("no reduction")) return rest.split(":")[0].trim();
+    }
+  }
+  return null;
+}
+
+function eventTool(event: Record<string, unknown>): string {
+  return typeof event.toolName === "string" && event.toolName ? event.toolName : "tool_result";
+}
+
+function writeMetric(partial: {
+  tool: string;
+  reducer: string | null;
+  before: number;
+  after: number;
+  changed: boolean;
+}): void {
+  if (!METRICS_PATH) return;
+  try {
+    const event = {
+      schemaVersion: 1,
+      eventId:
+        typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+          ? crypto.randomUUID()
+          : `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      ts: new Date().toISOString(),
+      harness: "omp",
+      tool: partial.tool,
+      reducer: partial.reducer,
+      beforeChars: partial.before,
+      afterChars: partial.after,
+      changed: partial.changed,
+      beforeTokens: null,
+      afterTokens: null,
+    };
+    fs.mkdirSync(path.dirname(path.resolve(METRICS_PATH)), { recursive: true });
+    fs.appendFileSync(METRICS_PATH, JSON.stringify(event) + "\n");
+  } catch {
+    /* telemetry must never break the hook */
+  }
+}
+
+export default function harnessTrim(pi: { on(event: string, handler: (event: unknown) => unknown): void }): void {
+  if (MODE === "off") return;
+  pi.on("tool_result", (event) => {
+    const ev = event as { content?: TextChunk[] };
+    if (!Array.isArray(ev.content)) return;
+    let changed = false;
+    const content = ev.content.map((chunk: TextChunk) => {
+      if (chunk.type !== "text" || typeof chunk.text !== "string") return chunk;
+      const text = chunk.text;
+      if (text.length < MIN_LENGTH || text.includes(MARKER)) return chunk;
+
+      const { output: reduced, reducer } = reduce(text);
+      if (!reduced || reduced.length >= text.length) {
+        if (METRICS_PATH) {
+          writeMetric({ tool: eventTool(ev), reducer: null, before: text.length, after: text.length, changed: false });
+        }
+        return chunk;
+      }
+
+      if (MODE === "dryrun") {
+        process.stderr.write(`[harnesstrim] dryrun OMP tool_result: ${text.length} -> ${reduced.length} chars\n`);
+        if (METRICS_PATH) {
+          writeMetric({ tool: eventTool(ev), reducer, before: text.length, after: reduced.length, changed: true });
+        }
+        return chunk;
+      }
+
+      changed = true;
+      if (METRICS_PATH) {
+        writeMetric({ tool: eventTool(ev), reducer, before: text.length, after: reduced.length, changed: true });
+      }
+      return { ...chunk, text: reduced };
+    });
+    return changed ? { content } : undefined;
+  });
+}

--- a/packages/adapter-omp/package.json
+++ b/packages/adapter-omp/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@harnesstrim/adapter-omp",
+  "version": "0.0.1",
+  "description": "HarnessTrim adapter for OMP (oh-my-pi): a tool_result reducer hook + install planner.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "node --test \"src/**/*.test.ts\"",
+    "typecheck": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/adapter-omp/src/index.test.ts
+++ b/packages/adapter-omp/src/index.test.ts
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import {
+  planOmpInstall,
+  DEFAULT_OMP_ADAPTER_CONFIG,
+  resolveOmpConfig,
+  bakeOmpConfig,
+  OMP_HOOK_NAME,
+  OMP_CONFIG_NAME,
+  OMP_HOOK_MARKER,
+} from "./index.ts";
+
+const base = {
+  installDir: "/proj",
+  hookSourceDir: "/repo/packages/adapter-omp/hook",
+  hookFileExists: false,
+  hookContent: null,
+};
+
+test("plans a project hook into .omp/hooks/post/harnesstrim.ts", () => {
+  const plan = planOmpInstall(base);
+  assert.equal(plan.hookDest, path.join("/proj", ".omp", "hooks", "post", OMP_HOOK_NAME));
+  assert.equal(plan.configDest, path.join("/proj", ".omp", "hooks", OMP_CONFIG_NAME));
+  assert.equal(plan.alreadyInstalled, false);
+});
+
+test("plans a user hook into ~/.omp/agent/hooks/post", () => {
+  const plan = planOmpInstall({ ...base, scope: "user" });
+  assert.equal(plan.hookDest, path.join("/proj", ".omp", "agent", "hooks", "post", OMP_HOOK_NAME));
+});
+
+test("not already-installed when the file exists but is not ours (no marker)", () => {
+  const plan = planOmpInstall({ ...base, hookFileExists: true, hookContent: "export default () => {}" });
+  assert.equal(plan.alreadyInstalled, false);
+});
+
+test("already-installed only when the file exists AND carries our marker", () => {
+  const plan = planOmpInstall({
+    ...base,
+    hookFileExists: true,
+    hookContent: `// ${OMP_HOOK_MARKER}\nexport default function (pi) {}`,
+  });
+  assert.equal(plan.alreadyInstalled, true);
+});
+
+test("default config is dryrun/400 and bakes deterministically", () => {
+  assert.deepEqual(DEFAULT_OMP_ADAPTER_CONFIG, { mode: "dryrun", minLength: 400 });
+  assert.equal(bakeOmpConfig(DEFAULT_OMP_ADAPTER_CONFIG), '{\n  "mode": "dryrun",\n  "minLength": 400\n}\n');
+});
+
+test("resolveOmpConfig preserves a baked config and applies overrides", () => {
+  const baked = { mode: "active" as const, minLength: 2000 };
+  assert.deepEqual(resolveOmpConfig(baked), { mode: "active", minLength: 2000 });
+  assert.deepEqual(resolveOmpConfig(baked, { mode: "off" }), { mode: "off", minLength: 2000 });
+  const withMetrics = resolveOmpConfig(null, { metrics: ".harnesstrim/m.jsonl" });
+  assert.equal(withMetrics.metrics, ".harnesstrim/m.jsonl");
+});

--- a/packages/adapter-omp/src/index.ts
+++ b/packages/adapter-omp/src/index.ts
@@ -1,0 +1,117 @@
+import path from "node:path";
+
+/**
+ * HarnessTrim adapter for OMP (`@oh-my-pi/pi-coding-agent`, CLI `omp`).
+ *
+ * OMP loads default-export TS hook factories from `~/.omp/agent/hooks/post/*.ts`
+ * (global) and `.omp/hooks/post/*.ts` (project). Hooks are non-recursive — the
+ * loader scans the directory directly — and carry no trust gate: discovered files
+ * are loaded through the extension runner at session start (verified against the
+ * 17.2.4 binary and docs; the post/pre discovery+load wiring ship since #2798).
+ *
+ * Our hook (`hook/harnesstrim.ts`) registers a `tool_result` handler that slims
+ * noisy tool output before it reaches the model — OMP's deterministic tool-output
+ * hook, analogous to Pi's extension and OpenCode's `tool.execute.after`. Installed
+ * by copying the factory into the hooks dir (content-marker-gated for uninstall)
+ * and baking the mode/min-length/metrics state into `harnesstrim.json` in the
+ * parent hooks dir (outside `post/` so the loader never sees it).
+ */
+
+export const OMP_HOOK_NAME = "harnesstrim.ts";
+export const OMP_CONFIG_NAME = "harnesstrim.json";
+/** Marker comment embedded in the shipped hook, used to recognize the file as ours. */
+export const OMP_HOOK_MARKER = "harnesstrim:omp-hook";
+
+/**
+ * Config baked into `harnesstrim.json` beside the hooks dir. The hook reads env
+ * first (HARNESSTRIM_MODE / HARNESSTRIM_MINLENGTH / HARNESSTRIM_METRICS win at
+ * runtime), then this file, then its built-in defaults.
+ */
+export interface OmpAdapterConfig {
+  /** `active` reduces in place; `dryrun` logs only; `off` disables. */
+  mode: "active" | "dryrun" | "off";
+  /** Tool outputs shorter than this (chars) are left untouched. */
+  minLength: number;
+  /** When set, append a TrimEvent JSONL receipt per reduction to this path. */
+  metrics?: string;
+}
+
+/** The config `install omp` writes when no options are given (hook default). */
+export const DEFAULT_OMP_ADAPTER_CONFIG: OmpAdapterConfig = { mode: "dryrun", minLength: 400 };
+
+/** True when the value looks like a known hook mode. */
+export function isOmpMode(v: unknown): v is OmpAdapterConfig["mode"] {
+  return v === "active" || v === "dryrun" || v === "off";
+}
+
+/** Merge explicit overrides over an existing/parsed config, keeping the rest. */
+export function resolveOmpConfig(
+  existing: Partial<OmpAdapterConfig> | null,
+  overrides: { mode?: OmpAdapterConfig["mode"]; minLength?: number; metrics?: string } = {}
+): OmpAdapterConfig {
+  const base = existing ?? DEFAULT_OMP_ADAPTER_CONFIG;
+  const config: OmpAdapterConfig = {
+    mode: overrides.mode ?? (isOmpMode(base.mode) ? base.mode : DEFAULT_OMP_ADAPTER_CONFIG.mode),
+    minLength:
+      overrides.minLength ??
+      (typeof base.minLength === "number" && base.minLength > 0
+        ? base.minLength
+        : DEFAULT_OMP_ADAPTER_CONFIG.minLength),
+  };
+  const metrics = overrides.metrics ?? base.metrics;
+  if (typeof metrics === "string" && metrics.length > 0) config.metrics = metrics;
+  return config;
+}
+
+/** Deterministic, sorted-key JSON for the config file (also used for digests). */
+export function bakeOmpConfig(config: OmpAdapterConfig): string {
+  const out: Record<string, unknown> = { mode: config.mode, minLength: config.minLength };
+  if (config.metrics) out.metrics = config.metrics;
+  return JSON.stringify(out, null, 2) + "\n";
+}
+
+export interface OmpInstallPlan {
+  /** Destination hook file (e.g. ~/.omp/agent/hooks/post/harnesstrim.ts). */
+  hookDest: string;
+  /** Source hook file (packages/adapter-omp/hook/harnesstrim.ts). */
+  hookSource: string;
+  /** Destination config file (e.g. ~/.omp/agent/hooks/harnesstrim.json). */
+  configDest: string;
+  /** True if the hook file exists AND carries our marker (idempotent). */
+  alreadyInstalled: boolean;
+}
+
+export interface OmpInstallInput {
+  /** Target install dir (project root, or the user's home for a global install). */
+  installDir: string;
+  /** Source dir of the shipped hook (packages/adapter-omp/hook/). */
+  hookSourceDir: string;
+  /** Whether a file named `harnesstrim.ts` exists in the destination hooks dir. */
+  hookFileExists: boolean;
+  /** Content of the existing hook file, or null. */
+  hookContent: string | null;
+  /** Whether installation targets the user's global OMP hooks directory. */
+  scope?: "user" | "project";
+}
+
+function hooksDir(installDir: string, scope: "user" | "project"): string {
+  return scope === "user"
+    ? path.join(installDir, ".omp", "agent", "hooks")
+    : path.join(installDir, ".omp", "hooks");
+}
+
+/**
+ * Compute what an OMP install would do. Pure — no filesystem access. The hook is
+ * considered already installed when the hook file exists and carries our marker
+ * (a same-named file the user wrote independently is never treated as ours).
+ */
+export function planOmpInstall(input: OmpInstallInput): OmpInstallPlan {
+  const scope = input.scope ?? "project";
+  const hooks = hooksDir(input.installDir, scope);
+  return {
+    hookDest: path.join(hooks, "post", OMP_HOOK_NAME),
+    hookSource: path.join(input.hookSourceDir, OMP_HOOK_NAME),
+    configDest: path.join(hooks, OMP_CONFIG_NAME),
+    alreadyInstalled: input.hookFileExists && input.hookContent !== null && input.hookContent.includes(OMP_HOOK_MARKER),
+  };
+}

--- a/packages/adapter-omp/tsconfig.json
+++ b/packages/adapter-omp/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src", "hook"]
+}

--- a/packages/adapter-pi/extension/index.ts
+++ b/packages/adapter-pi/extension/index.ts
@@ -7,10 +7,20 @@
 // and loads from `~/.pi/agent/extensions/` or `<project>/.pi/extensions/`.
 //
 // Requires `harnesstrim` on PATH; if it is missing or fails, the output is passed through
-// unchanged (a reducer must never break a tool result). Config via env:
-//   HARNESSTRIM_MODE=dryrun|active|off   (default dryrun — logs, does not mutate)
-//   HARNESSTRIM_MINLENGTH=<chars>        (default 400)
+// unchanged (a reducer must never break a tool result).
+//
+// Config precedence (highest first):
+//   1. Environment: HARNESSTRIM_MODE=dryrun|active|off, HARNESSTRIM_MINLENGTH=<chars>,
+//      HARNESSTRIM_METRICS=<path>   (default dryrun — logs, does not mutate; min 400)
+//   2. config.json beside this file (written by `harnesstrim install pi --apply`
+//      with --mode/--min-length/--metrics)
+//   3. built-in defaults below.
+//
+// --metrics records a TrimEvent JSONL receipt per reduction attempt (read by
+// `harnesstrim metrics`), the receipt that makes interception verifiable.
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 
 type TextContent = { type: "text"; text: string };
 type ToolContent = TextContent | { type: string; [key: string]: unknown };
@@ -25,29 +35,119 @@ interface ExtensionAPI {
 
 const runtime = globalThis as typeof globalThis & { process?: NodeJS.Process };
 const env = runtime.process?.env ?? {};
-const MODE = env.HARNESSTRIM_MODE ?? "dryrun";
-const MIN_LENGTH = Number(env.HARNESSTRIM_MINLENGTH ?? "400") || 400;
 const MARKER = "[harnesstrim";
+
+/** The directory this extension file lives in (the installed extension dir). */
+const HERE =
+  (typeof import.meta !== "undefined" &&
+    (import.meta as { dirname?: string }).dirname) ||
+  "";
+
+interface BakedConfig {
+  mode?: string;
+  minLength?: number;
+  metrics?: string;
+}
+
+function readBakedConfig(): BakedConfig {
+  if (!HERE) return {};
+  try {
+    const raw = fs.readFileSync(path.join(HERE, "config.json"), "utf8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return {
+      mode: typeof parsed.mode === "string" ? parsed.mode : undefined,
+      minLength: typeof parsed.minLength === "number" ? parsed.minLength : undefined,
+      metrics: typeof parsed.metrics === "string" ? parsed.metrics : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
+function resolveMode(): string {
+  return env.HARNESSTRIM_MODE ?? readBakedConfig().mode ?? "dryrun";
+}
+
+function resolveMinLength(): number {
+  const baked = readBakedConfig().minLength;
+  const raw = env.HARNESSTRIM_MINLENGTH ?? (baked !== undefined ? String(baked) : "400");
+  return Number(raw) || 400;
+}
+
+function resolveMetricsPath(): string | undefined {
+  return env.HARNESSTRIM_METRICS || readBakedConfig().metrics || undefined;
+}
+
+const MODE = resolveMode();
+const MIN_LENGTH = resolveMinLength();
+const METRICS_PATH = resolveMetricsPath();
 
 /** True when a text chunk should not be reduced: too short, or already reduced. */
 export function shouldSkip(text: string, minLength: number): boolean {
   return text.length < minLength || text.includes(MARKER);
 }
 
-function reduceViaCli(text: string): string | null {
+/** Parse the reducer name from `harnesstrim reduce --stats` stderr, if any. */
+function parseReducer(stderr: string): string | null {
+  for (const line of stderr.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("[harnesstrim reduce]")) {
+      const rest = trimmed.slice("[harnesstrim reduce] ".length);
+      if (rest.includes(":") && !rest.includes("no reduction")) return rest.split(":")[0].trim();
+    }
+  }
+  return null;
+}
+
+function reduceViaCli(text: string): { output: string | null; reducer: string | null } {
   try {
-    const r = spawnSync("harnesstrim", ["reduce", "--min-length", String(MIN_LENGTH)], {
+    const r = spawnSync("harnesstrim", ["reduce", "--min-length", String(MIN_LENGTH), "--stats"], {
       input: text,
       encoding: "utf8",
       timeout: 30000,
     });
     if (r.status === 0 && typeof r.stdout === "string" && r.stdout.length > 0) {
-      return r.stdout.replace(/\n$/, "");
+      const output = r.stdout.replace(/\n$/, "");
+      const reducer = typeof r.stderr === "string" ? parseReducer(r.stderr) : null;
+      return { output, reducer };
     }
   } catch {
     /* harnesstrim not on PATH or failed — pass through */
   }
-  return null;
+  return { output: null, reducer: null };
+}
+
+/** Append a TrimEvent JSONL receipt (self-contained: no workspace imports allowed). */
+function writeMetric(partial: {
+  tool: string;
+  reducer: string | null;
+  before: number;
+  after: number;
+  changed: boolean;
+}): void {
+  if (!METRICS_PATH) return;
+  try {
+    const event = {
+      schemaVersion: 1,
+      eventId:
+        typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+          ? crypto.randomUUID()
+          : `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      ts: new Date().toISOString(),
+      harness: "pi",
+      tool: partial.tool,
+      reducer: partial.reducer,
+      beforeChars: partial.before,
+      afterChars: partial.after,
+      changed: partial.changed,
+      beforeTokens: null,
+      afterTokens: null,
+    };
+    fs.mkdirSync(path.dirname(path.resolve(METRICS_PATH)), { recursive: true });
+    fs.appendFileSync(METRICS_PATH, JSON.stringify(event) + "\n");
+  } catch {
+    /* telemetry must never break the extension */
+  }
 }
 
 export default function harnesstrim(pi: ExtensionAPI): void {
@@ -61,20 +161,39 @@ export default function harnesstrim(pi: ExtensionAPI): void {
       const text = chunk.text;
       if (shouldSkip(text, MIN_LENGTH)) return chunk;
 
-      const reduced = reduceViaCli(text);
-      if (!reduced || reduced.length >= text.length) return chunk;
+      const { output: reduced, reducer } = reduceViaCli(text);
+      if (!reduced || reduced.length >= text.length) {
+        // Attempted reduction, nothing changed — a recorded pass-through.
+        if (METRICS_PATH) {
+          writeMetric({ tool: eventTool(event), reducer: null, before: text.length, after: text.length, changed: false });
+        }
+        return chunk;
+      }
 
       if (MODE === "dryrun") {
         runtime.process?.stderr?.write(
           `[harnesstrim] dryrun tool_result: ${text.length} -> ${reduced.length} chars\n`
         );
+        // Receipt with the would-be counts — dryrun's value is proof it WOULD reduce.
+        if (METRICS_PATH) {
+          writeMetric({ tool: eventTool(event), reducer, before: text.length, after: reduced.length, changed: true });
+        }
         return chunk;
       }
 
       changed = true;
+      if (METRICS_PATH) {
+        writeMetric({ tool: eventTool(event), reducer, before: text.length, after: reduced.length, changed: true });
+      }
       return { ...chunk, text: reduced };
     });
 
     return changed ? { content } : undefined;
   });
+}
+
+/** Best-effort tool name from the event (Pi's event carries toolName when present). */
+function eventTool(event: ToolResultEvent): string {
+  const name = (event as ToolResultEvent & { toolName?: string }).toolName;
+  return typeof name === "string" && name.length > 0 ? name : "tool_result";
 }

--- a/packages/adapter-pi/src/index.test.ts
+++ b/packages/adapter-pi/src/index.test.ts
@@ -32,7 +32,9 @@ test("already-installed only when dir exists AND marker present", () => {
   assert.equal(plan.alreadyInstalled, true);
 });
 
-test("marker content mentions the extension and dryrun default", () => {
+test("marker content mentions the extension, config.json, and dryrun default", () => {
   assert.match(markerFileContent(), /pi-extension/);
-  assert.match(markerFileContent(), /HARNESSTRIM_MODE=active/);
+  assert.match(markerFileContent(), /HARNESSTRIM_MODE/);
+  assert.match(markerFileContent(), /config\.json/);
+  assert.match(markerFileContent(), /dryrun/);
 });

--- a/packages/adapter-pi/src/index.ts
+++ b/packages/adapter-pi/src/index.ts
@@ -13,6 +13,54 @@ import path from "node:path";
  */
 export const PI_EXTENSION_NAME = "harnesstrim";
 
+/**
+ * Config baked into `config.json` inside the extension dir. The extension reads env
+ * first (HARNESSTRIM_MODE / HARNESSTRIM_MINLENGTH / HARNESSTRIM_METRICS win at
+ * runtime), then this file, then its built-in defaults.
+ */
+export interface PiAdapterConfig {
+  /** `active` reduces in place; `dryrun` logs only; `off` disables. */
+  mode: "active" | "dryrun" | "off";
+  /** Tool outputs shorter than this (chars) are left untouched. */
+  minLength: number;
+  /** When set, append a TrimEvent JSONL receipt per reduction to this path. */
+  metrics?: string;
+}
+
+/** The config `install pi` writes when no options are given (extension's own default). */
+export const DEFAULT_PI_ADAPTER_CONFIG: PiAdapterConfig = { mode: "dryrun", minLength: 400 };
+
+/** True when the value looks like a known extension mode. */
+export function isPiMode(v: unknown): v is PiAdapterConfig["mode"] {
+  return v === "active" || v === "dryrun" || v === "off";
+}
+
+/** Merge explicit overrides over an existing/parsed config, keeping the rest. */
+export function resolvePiConfig(
+  existing: Partial<PiAdapterConfig> | null,
+  overrides: { mode?: PiAdapterConfig["mode"]; minLength?: number; metrics?: string } = {}
+): PiAdapterConfig {
+  const base = existing ?? DEFAULT_PI_ADAPTER_CONFIG;
+  const config: PiAdapterConfig = {
+    mode: overrides.mode ?? (isPiMode(base.mode) ? base.mode : DEFAULT_PI_ADAPTER_CONFIG.mode),
+    minLength:
+      overrides.minLength ??
+      (typeof base.minLength === "number" && base.minLength > 0
+        ? base.minLength
+        : DEFAULT_PI_ADAPTER_CONFIG.minLength),
+  };
+  const metrics = overrides.metrics ?? base.metrics;
+  if (typeof metrics === "string" && metrics.length > 0) config.metrics = metrics;
+  return config;
+}
+
+/** Deterministic, sorted-key JSON for the config file (also used for digests). */
+export function bakePiConfig(config: PiAdapterConfig): string {
+  const out: Record<string, unknown> = { mode: config.mode, minLength: config.minLength };
+  if (config.metrics) out.metrics = config.metrics;
+  return JSON.stringify(out, null, 2) + "\n";
+}
+
 export interface PiInstallPlan {
   /** Destination dir for the extension bundle (e.g. <project>/.pi/extensions/harnesstrim/). */
   extensionDest: string;
@@ -56,8 +104,10 @@ export function markerFileContent(): string {
     `# harnesstrim:pi-extension`,
     ``,
     `Installed by \`harnesstrim install pi --apply\`. The extension registers a`,
-    `tool_result handler that slims noisy tool output. Set HARNESSTRIM_MODE=active in`,
-    `Pi's environment to reduce (default is dryrun). Remove this directory to uninstall.`,
+    `tool_result handler that slims noisy tool output. The installed state lives in`,
+    `config.json (mode/minLength/metrics, set via install flags); environment`,
+    `HARNESSTRIM_MODE/HARNESSTRIM_MINLENGTH/HARNESSTRIM_METRICS override it at runtime.`,
+    `Default mode is dryrun. Remove this directory to uninstall.`,
     ``,
   ].join("\n");
 }

--- a/packages/cli/build.mjs
+++ b/packages/cli/build.mjs
@@ -5,6 +5,7 @@
 //   assets/skills/       <- the shipped skill pack
 //   assets/adapter-hermes/plugin/    <- the Hermes plugin bundle
 //   assets/adapter-pi/extension/     <- the Pi extension bundle
+//   assets/adapter-omp/hook/         <- the OMP hook bundle
 //
 // The bundle carries no runtime dependencies, so `npx harnesstrim` works
 // standalone. assets.ts resolves these directories next to the bundle in a
@@ -46,6 +47,10 @@ copyDir(
   path.join(repoRoot, "packages", "adapter-pi", "extension"),
   path.join(assetsDir, "adapter-pi", "extension"),
 );
+copyDir(
+  path.join(repoRoot, "packages", "adapter-omp", "hook"),
+  path.join(assetsDir, "adapter-omp", "hook"),
+);
 
 // 3. Bundle. Everything is inlined (workspace packages are unpublished; js-tiktoken,
 // the MCP SDK and zod are pulled in so the published package needs no dependencies).
@@ -60,9 +65,8 @@ await build({
   // `bench` is a repo-development command: it reads the benchmark fixtures and
   // writes a report, and the benchmarks module auto-runs when its own URL matches
   // process.argv[1] — which is true for *any* entry once bundled. Keep it external
-  // so importing it can't fire that guard, and so js-tiktoken stays out of the
-  // published bundle. In a standalone install the dynamic import fails and the CLI
-  // prints a dev-tool message (see the "bench" case in cli.ts).
+  // so importing it can't fire that guard. In a standalone install the dynamic
+  // import fails and the CLI prints a dev-tool message (see the "bench" case in cli.ts).
   external: ["@harnesstrim/benchmarks/run"],
 });
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,11 +18,13 @@
     "@harnesstrim/adapter-claude": "workspace:*",
     "@harnesstrim/adapter-codex": "workspace:*",
     "@harnesstrim/adapter-hermes": "workspace:*",
+    "@harnesstrim/adapter-omp": "workspace:*",
     "@harnesstrim/adapter-pi": "workspace:*",
     "@harnesstrim/benchmarks": "workspace:*",
     "@harnesstrim/core": "workspace:*",
     "@harnesstrim/mcp": "workspace:*",
-    "esbuild": "^0.25.0"
+    "esbuild": "^0.25.0",
+    "js-tiktoken": "^1.0.15"
   },
   "scripts": {
     "build": "node build.mjs",

--- a/packages/cli/smoke-test.sh
+++ b/packages/cli/smoke-test.sh
@@ -61,14 +61,18 @@ LINT_WALL="$LINT_WALL
   0 errors"
 REDUCED="$(printf '%s\n' "$LINT_WALL" | "$BIN" reduce --metrics "$PROJ/m.jsonl" 2>/dev/null)" || fail "reduce exited non-zero"
 echo "$REDUCED" | grep -q "harnesstrim:lint-output-slim" || fail "reduce did not run lint-output-slim"
+# The reduce path is a standalone process: its receipt carries exact cl100k token
+# counts (the tokenizer is bundled, unlike in-harness adapters which report null).
+grep -q '"beforeTokens": [0-9]' "$PROJ/m.jsonl" || fail "reduce receipt missing beforeTokens count"
+grep -q '"afterTokens": [0-9]' "$PROJ/m.jsonl" || fail "reduce receipt missing afterTokens count"
 # --min-length raises the threshold: a reducible input with a huge threshold passes through.
 REDUCED_HIGH="$(printf '%s\n' "$LINT_WALL" | "$BIN" reduce --min-length 999999 2>/dev/null)" || fail "reduce --min-length exited non-zero"
 echo "$REDUCED_HIGH" | grep -q "harnesstrim:lint-output-slim" && fail "reduce --min-length 999999 should not reduce"
 [ "$REDUCED_HIGH" = "$LINT_WALL" ] || fail "reduce --min-length 999999 changed the input"
 
 # 6. Every installer runs dry-run then --apply from a clean dir, using the
-#    shipped assets (skills / hermes plugin / pi extension).
-for t in opencode codex claude hermes pi; do
+#    shipped assets (skills / hermes plugin / pi extension / omp hook).
+for t in opencode codex claude hermes pi omp; do
   "$BIN" install "$t" "$D" >/dev/null 2>&1 || fail "install $t (dry-run)"
   "$BIN" install "$t" "$D" --apply >/dev/null 2>&1 || fail "install $t --apply"
   # Second --apply must be idempotent (no error).
@@ -79,8 +83,10 @@ done
 [ -d "$D/.claude/skills" ] || fail "claude skills not written"
 [ -d "$D/.pi/extensions/harnesstrim" ] || fail "pi extension not written"
 [ -d "$D/.hermes" ] || fail "hermes plugin not written"
+[ -d "$D/.omp/hooks/post" ] || fail "omp hook not written"
+[ -f "$D/.omp/hooks/harnesstrim.json" ] || fail "omp baked config not written"
 SKILLS="$("$BIN" preset list 2>/dev/null | head -1)" # sanity: presets resolve
-echo "== smoke: installers applied (opencode/codex/claude/hermes/pi), assets present =="
+echo "== smoke: installers applied (opencode/codex/claude/hermes/pi/omp), assets present =="
 
 # 6a. Narrowed installs write only what they promise.
 ND="$PROJ/narrowed"
@@ -97,12 +103,32 @@ grep -q '"minLength": 2000' "$ND/.opencode/plugin/harnesstrim.ts" || fail "openc
 grep -q '"toolFilter"' "$ND/.opencode/plugin/harnesstrim.ts" || fail "opencode wrapper missing toolFilter"
 grep -q '"bash"' "$ND/.opencode/plugin/harnesstrim.ts" || fail "opencode wrapper missing bash in toolFilter"
 
-# 6b. capabilities is valid JSON and names all five harnesses.
+# 6a2. hermes / pi / omp bake --mode + --min-length into their config.json, and the
+#      baked config survives a plain re-`--apply` (state preservation).
+HDP="$PROJ/hdp"
+mkdir -p "$HDP"
+"$BIN" install hermes "$HDP" --mode active --min-length 800 --apply >/dev/null 2>&1 || fail "install hermes --mode/--min-length --apply"
+grep -q '"mode": "active"' "$HDP/.hermes/plugins/harnesstrim/config.json" || fail "hermes config missing mode active"
+grep -q '"minLength": 800' "$HDP/.hermes/plugins/harnesstrim/config.json" || fail "hermes config missing minLength 800"
+"$BIN" install hermes "$HDP" --apply >/dev/null 2>&1 || fail "install hermes (2nd, idempotency)"
+grep -q '"mode": "active"' "$HDP/.hermes/plugins/harnesstrim/config.json" || fail "hermes re-apply reset the baked mode"
+PDP="$PROJ/pdp"
+mkdir -p "$PDP"
+"$BIN" install pi "$PDP" --mode active --min-length 500 --metrics "$PDP/m.jsonl" --apply >/dev/null 2>&1 || fail "install pi --mode/--min-length/--metrics --apply"
+grep -q '"metrics"' "$PDP/.pi/extensions/harnesstrim/config.json" || fail "pi config missing baked metrics path"
+ODP="$PROJ/odp"
+mkdir -p "$ODP"
+"$BIN" install omp "$ODP" --mode active --min-length 300 --metrics "$ODP/m.jsonl" --apply >/dev/null 2>&1 || fail "install omp --mode/--min-length/--metrics --apply"
+grep -q '"minLength": 300' "$ODP/.omp/hooks/harnesstrim.json" || fail "omp config missing minLength 300"
+
+# 6b. capabilities is valid JSON, names all six harnesses, and carries digests.
 CAPS="$(node -e "JSON.parse(require('fs').readFileSync(0,'utf8'))" <<< "$("$BIN" capabilities 2>/dev/null)" && echo ok)" || fail "capabilities did not emit valid JSON"
 [ "$CAPS" = "ok" ] || fail "capabilities invalid JSON"
-for h in opencode codex claude hermes pi; do
+for h in opencode codex claude hermes pi omp; do
   "$BIN" capabilities 2>/dev/null | grep -q "\"$h\"" || fail "capabilities missing harness $h"
 done
+"$BIN" capabilities 2>/dev/null | grep -q '"digests"' || fail "capabilities missing digests"
+FLAT_SHA="$(node -e "const c=JSON.parse(require('fs').readFileSync(0,'utf8'));for(const d of Object.values(c.digests))for(const v of Object.values(d))if(!/^[0-9a-f]{64}$/.test(v))process.exit(1)" <<< "$("$BIN" capabilities 2>/dev/null)")" || fail "capabilities digest values are not sha256 hex"
 
 # 6c. --json works for doctor / install / metrics (one JSON object on stdout).
 node -e "JSON.parse(require('fs').readFileSync(0,'utf8'))" <<< "$("$BIN" doctor "$D" --json 2>/dev/null)" || fail "doctor --json invalid"
@@ -117,7 +143,11 @@ node -e "JSON.parse(require('fs').readFileSync(0,'utf8'))" <<< "$("$BIN" install
 [ -d "$D/.opencode/plugin" ] && fail "uninstall opencode --apply left the wrapper"
 "$BIN" uninstall claude "$D" --apply >/dev/null 2>&1 || fail "uninstall claude --apply"
 [ -d "$D/.claude/skills" ] && fail "uninstall claude --apply left skills"
-echo "== smoke: capabilities + --json + narrowing + uninstall verified =="
+"$BIN" uninstall omp "$D" >/dev/null 2>&1 || fail "uninstall omp (dry-run)"
+[ -f "$D/.omp/hooks/post/harnesstrim.ts" ] || fail "uninstall omp dry-run removed files without --apply"
+"$BIN" uninstall omp "$D" --apply >/dev/null 2>&1 || fail "uninstall omp --apply"
+[ -f "$D/.omp/hooks/post/harnesstrim.ts" ] && fail "uninstall omp --apply left the hook"
+echo "== smoke: capabilities + digests + --json + narrowing + uninstall verified =="
 
 # 7. mcp stdio handshake exposes the reduce tool.
 MCP_OUT="$(printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}\n' | timeout 10 "$BIN" mcp 2>/dev/null)" || fail "mcp initialize"

--- a/packages/cli/src/assets.ts
+++ b/packages/cli/src/assets.ts
@@ -38,3 +38,8 @@ export function resolveHermesPluginSourceDir(): string {
 export function resolvePiExtensionSourceDir(): string {
   return resolveAssetDir(path.join("adapter-pi", "extension"), path.join("packages", "adapter-pi", "extension"));
 }
+
+/** The shipped OMP hook bundle (harnesstrim.ts, a hooks/post factory). */
+export function resolveOmpHookSourceDir(): string {
+  return resolveAssetDir(path.join("adapter-omp", "hook"), path.join("packages", "adapter-omp", "hook"));
+}

--- a/packages/cli/src/capabilities.test.ts
+++ b/packages/cli/src/capabilities.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { getCapabilities, CAPABILITIES } from "./capabilities.ts";
+import { getCapabilities } from "./capabilities.ts";
 import {
   opencodeInstallJson,
   claudeInstallJson,
@@ -22,18 +22,36 @@ function tmpProject(): string {
 }
 
 test("capabilities covers every supported harness and flags", () => {
-  const caps = getCapabilities("0.0.7");
-  assert.equal(caps.version, "0.0.7");
+  const caps = getCapabilities("0.1.0");
+  assert.equal(caps.version, "0.1.0");
   const names = Object.keys(caps.harnesses);
-  for (const h of ["opencode", "codex", "claude", "hermes", "pi"]) assert.ok(names.includes(h));
+  for (const h of ["opencode", "codex", "claude", "hermes", "pi", "omp"]) assert.ok(names.includes(h));
   // the narrowing flags the plan requires are documented
-  assert.ok(CAPABILITIES.harnesses.claude.narrowing.some((n) => n.flag === "--no-hook"));
-  assert.ok(CAPABILITIES.harnesses.claude.narrowing.some((n) => n.flag === "--no-instructions"));
-  assert.ok(CAPABILITIES.harnesses.codex.narrowing.some((n) => n.flag === "--no-instructions"));
-  assert.ok(CAPABILITIES.harnesses.opencode.narrowing.some((n) => n.flag === "--mode active|dryrun|off"));
-  assert.ok(CAPABILITIES.harnesses.opencode.narrowing.some((n) => n.flag === "--tools <name,...>"));
+  const h = caps.harnesses;
+  assert.ok(h["claude"].narrowing.some((n) => n.flag === "--no-hook"));
+  assert.ok(h["claude"].narrowing.some((n) => n.flag === "--no-instructions"));
+  assert.ok(h["codex"].narrowing.some((n) => n.flag === "--no-instructions"));
+  assert.ok(h["opencode"].narrowing.some((n) => n.flag === "--mode active|dryrun|off"));
+  assert.ok(h["opencode"].narrowing.some((n) => n.flag === "--tools <name,...>"));
+  assert.ok(h["hermes"].narrowing.some((n) => n.flag === "--min-length <n>"));
+  assert.ok(h["pi"].narrowing.some((n) => n.flag.startsWith("--metrics")));
+  assert.ok(h["omp"].narrowing.some((n) => n.flag.startsWith("--mode")));
   // every harness documents its reviewed write set
   for (const h of Object.values(caps.harnesses)) assert.ok(h.writeSet.length > 0);
+});
+
+test("capabilities digests pin the content install would write", () => {
+  const caps = getCapabilities("0.1.0");
+  assert.ok(caps.digests);
+  for (const h of ["opencode", "codex", "claude", "hermes", "pi", "omp"]) {
+    const d = caps.digests[h];
+    assert.ok(d && Object.keys(d).length > 0, `digests for ${h}`);
+  }
+  // deterministic rerun yields identical digests (release-verification table)
+  assert.deepEqual(getCapabilities("0.1.0").digests, caps.digests);
+  // digests actually pin content: hashing the known snippet text must match
+  const codexDigest = Object.values(caps.digests.codex).find((v) => typeof v === "string");
+  assert.equal(codexDigest?.length, 64);
 });
 
 test("doctorJson is valid JSON with the report shape", () => {

--- a/packages/cli/src/capabilities.ts
+++ b/packages/cli/src/capabilities.ts
@@ -7,6 +7,8 @@
  * per-version table anywhere. Update this file when a surface or an install flag changes.
  */
 
+import { computeHarnessDigests, type HarnessDigests } from "./digests.ts";
+
 export interface CapabilityNarrowing {
   /** The CLI flag that produces the narrower install state. */
   flag: string;
@@ -29,69 +31,102 @@ export interface Capabilities {
   /** CLI version this table describes. */
   version: string;
   harnesses: Record<string, HarnessCapabilities>;
+  /**
+   * SHA-256 digests of the artifact content this version would write, keyed by the
+   * path (relative to the install dir, forward slashes). Consumers hash their copy
+   * and compare — the release-verification table that replaces hand-pinned upstream
+   * versions. Computed from the same shipped sources `install` reads.
+   */
+  digests: Record<string, HarnessDigests>;
 }
 
-export const CAPABILITIES: Omit<Capabilities, "version"> = {
-  harnesses: {
-    opencode: {
-      adapter: "@harnesstrim/adapter-opencode",
-      surfaces: [
-        "tool.execute.after — slims noisy tool output in place before it enters context",
-        "experimental.session.compacting — injects compaction-handoff guidance",
-      ],
-      narrowing: [
-        { flag: "--mode active|dryrun|off", produces: "bake the reduction mode into the generated wrapper (active/dryrun/off)" },
-        { flag: "--min-length <n>", produces: "leave tool outputs shorter than n chars untouched (overrides preset)" },
-        { flag: "--tools <name,...>", produces: "confine reduction to a subset of tool families (e.g. bash,read)" },
-        { flag: "--preset <name>", produces: "bake a policy preset's adapter config into the wrapper" },
-      ],
-      writeSet: [
-        ".opencode/plugin/harnesstrim.ts",
-        ".opencode/package.json",
-        "opencode.json (cleans a stale adapter entry, never adds one)",
-      ],
-    },
-    codex: {
-      adapter: "@harnesstrim/adapter-codex",
-      surfaces: [
-        "PostToolUse Bash hook — deterministic reduction of simple Bash output (optional --hook)",
-        "AGENTS.md reduce-pipe instruction — model pipes noisy output through `harnesstrim reduce`",
-        "MCP reduce tool — deterministic, instruction-free reduction (separate `harnesstrim mcp`)",
-      ],
-      narrowing: [
-        { flag: "--no-instructions", produces: "skills only — no AGENTS.md reduce-pipe instruction" },
-        { flag: "--hook", produces: "also install the experimental Bash PostToolUse hook" },
-        { flag: "--global", produces: "install the hook once in ~/.codex (with --hook)" },
-      ],
-      writeSet: [".codex/skills/", "AGENTS.md (marker-guarded snippet)", ".codex/hooks.json (with --hook)"],
-    },
-    claude: {
-      adapter: "@harnesstrim/adapter-claude",
-      surfaces: [
-        "PostToolUse Bash hook — spec-correct updatedToolOutput (not honored by Claude Code 2.1.37–2.1.212)",
-        "CLAUDE.md reduce-pipe instruction — the effective reduction path on current Claude Code",
-      ],
-      narrowing: [
-        { flag: "--no-hook", produces: "skills only — no PostToolUse hook in .claude/settings.json" },
-        { flag: "--no-instructions", produces: "skills only — no CLAUDE.md reduce-pipe instruction" },
-      ],
-      writeSet: [".claude/skills/", ".claude/settings.json", "CLAUDE.md (marker-guarded snippet)"],
-    },
-    hermes: {
-      adapter: "@harnesstrim/adapter-hermes",
-      surfaces: ["transform_tool_result — deterministic reduction before the result enters context"],
-      narrowing: [],
-      writeSet: [".hermes/plugins/harnesstrim/ (incl. .installed marker)"],
-    },
-    pi: {
-      adapter: "@harnesstrim/adapter-pi",
-      surfaces: ["tool_result — deterministic reduction of text chunks in structured results"],
-      narrowing: [],
-      writeSet: [".pi/extensions/harnesstrim/ or .pi/agent/extensions/harnesstrim/ (incl. .installed marker)"],
-    },
+export interface CapabilityState extends HarnessCapabilities {
+  /** Per-artifact digests for this harness (see `Capabilities.digests`). */
+  digests?: HarnessDigests;
+}
+
+export const CAPABILITIES: Record<string, HarnessCapabilities> = {
+  opencode: {
+    adapter: "@harnesstrim/adapter-opencode",
+    surfaces: [
+      "tool.execute.after — slims noisy tool output in place before it enters context",
+      "experimental.session.compacting — injects compaction-handoff guidance",
+    ],
+    narrowing: [
+      { flag: "--mode active|dryrun|off", produces: "bake the reduction mode into the generated wrapper (active/dryrun/off)" },
+      { flag: "--min-length <n>", produces: "leave tool outputs shorter than n chars untouched (overrides preset)" },
+      { flag: "--tools <name,...>", produces: "confine reduction to a subset of tool families (e.g. bash,read)" },
+      { flag: "--preset <name>", produces: "bake a policy preset's adapter config into the wrapper" },
+    ],
+    writeSet: [
+      ".opencode/plugin/harnesstrim.ts",
+      ".opencode/package.json",
+      "opencode.json (cleans a stale adapter entry, never adds one)",
+    ],
+  },
+  codex: {
+    adapter: "@harnesstrim/adapter-codex",
+    surfaces: [
+      "PostToolUse Bash hook — deterministic reduction of simple Bash output (optional --hook)",
+      "AGENTS.md reduce-pipe instruction — model pipes noisy output through `harnesstrim reduce`",
+      "MCP reduce tool — deterministic, instruction-free reduction (separate `harnesstrim mcp`)",
+    ],
+    narrowing: [
+      { flag: "--no-instructions", produces: "skills only — no AGENTS.md reduce-pipe instruction" },
+      { flag: "--hook", produces: "also install the experimental Bash PostToolUse hook" },
+      { flag: "--global", produces: "install the hook once in ~/.codex (with --hook)" },
+    ],
+    writeSet: [".codex/skills/", "AGENTS.md (marker-guarded snippet)", ".codex/hooks.json (with --hook)"],
+  },
+  claude: {
+    adapter: "@harnesstrim/adapter-claude",
+    surfaces: [
+      "PostToolUse Bash hook — spec-correct updatedToolOutput (not honored by Claude Code 2.1.37–2.1.212)",
+      "CLAUDE.md reduce-pipe instruction — the effective reduction path on current Claude Code",
+    ],
+    narrowing: [
+      { flag: "--no-hook", produces: "skills only — no PostToolUse hook in .claude/settings.json" },
+      { flag: "--no-instructions", produces: "skills only — no CLAUDE.md reduce-pipe instruction" },
+    ],
+    writeSet: [".claude/skills/", ".claude/settings.json", "CLAUDE.md (marker-guarded snippet)"],
+  },
+  hermes: {
+    adapter: "@harnesstrim/adapter-hermes",
+    surfaces: ["transform_tool_result — deterministic reduction before the result enters context"],
+    narrowing: [
+      { flag: "--mode active|dryrun|off", produces: "bake the reduction mode into the plugin's config.json (env HARNESSTRIM_MODE still wins)" },
+      { flag: "--min-length <n>", produces: "bake the min threshold into the plugin's config.json (env HARNESSTRIM_MINLENGTH still wins)" },
+    ],
+    writeSet: [".hermes/plugins/harnesstrim/ (incl. .installed marker + config.json)"],
+  },
+  pi: {
+    adapter: "@harnesstrim/adapter-pi",
+    surfaces: ["tool_result — deterministic reduction of text chunks in structured results"],
+    narrowing: [
+      { flag: "--mode active|dryrun|off", produces: "bake the reduction mode into the extension's config.json (env HARNESSTRIM_MODE still wins)" },
+      { flag: "--min-length <n>", produces: "bake the min threshold into the extension's config.json (env HARNESSTRIM_MINLENGTH still wins)" },
+      { flag: "--metrics <path>", produces: "write a TrimEvent JSONL receipt per reduction (proof of interception)" },
+    ],
+    writeSet: [".pi/extensions/harnesstrim/ (or .pi/agent/extensions/harnesstrim/, incl. .installed marker + config.json)"],
+  },
+  omp: {
+    adapter: "@harnesstrim/adapter-omp",
+    surfaces: [
+      "tool_result hook in hooks/post/ — deterministic reduction before the result enters context",
+      "Loaded by omp with no trust gate and no settings.json entry (file directly under hooks/post/)",
+    ],
+    narrowing: [
+      { flag: "--mode active|dryrun|off", produces: "bake the reduction mode into hooks/harnesstrim.json (env HARNESSTRIM_MODE still wins)" },
+      { flag: "--min-length <n>", produces: "bake the min threshold into hooks/harnesstrim.json (env HARNESSTRIM_MINLENGTH still wins)" },
+      { flag: "--metrics <path>", produces: "write a TrimEvent JSONL receipt per reduction (proof of interception)" },
+    ],
+    writeSet: [
+      ".omp/hooks/post/harnesstrim.ts (or ~/.omp/agent/hooks/post/harnesstrim.ts)",
+      ".omp/hooks/harnesstrim.json (or ~/.omp/agent/hooks/harnesstrim.json)",
+    ],
   },
 };
 
 export function getCapabilities(version: string): Capabilities {
-  return { version, ...CAPABILITIES };
+  return { version, harnesses: { ...CAPABILITIES }, digests: computeHarnessDigests() };
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,6 +10,8 @@ import { runInstallCodex, runInstallCodexGlobalHook } from "./install-codex.ts";
 import { runInstallClaude } from "./install-claude.ts";
 import { runInstallPi } from "./install-pi.ts";
 import { runInstallHermes } from "./install-hermes.ts";
+import { runInstallOmp } from "./install-omp.ts";
+import { countTokens } from "./tokens.ts";
 import { reduceClaudePayload } from "@harnesstrim/adapter-claude";
 import { reduceCodexPayload } from "@harnesstrim/adapter-codex";
 import { loadMetrics, DEFAULT_METRICS_PATH } from "./metrics.ts";
@@ -26,6 +28,7 @@ import {
   renderClaudeInstall,
   renderHermesInstall,
   renderPiInstall,
+  renderOmpInstall,
   renderMetrics,
   renderPresetList,
   renderPresetShow,
@@ -39,6 +42,7 @@ import {
   claudeInstallJson,
   hermesInstallJson,
   piInstallJson,
+  ompInstallJson,
   codexGlobalHookJson,
 } from "./json.ts";
 
@@ -63,8 +67,18 @@ Usage:
                             --no-instructions  Skills only (no CLAUDE.md reduce-pipe instruction)
   harnesstrim install hermes [dir]         Install Hermes plugin (dry-run)
                             --apply         Actually write the change
+                            --mode <m>      Bake mode: active|dryrun|off (env still wins)
+                            --min-length <n> Bake the min threshold (chars)
   harnesstrim install pi [dir]             Install Pi tool_result extension (dry-run)
                             --apply         Actually write the change
+                            --mode <m>      Bake mode: active|dryrun|off (env still wins)
+                            --min-length <n> Bake the min threshold (chars)
+                            --metrics <p>   Record a TrimEvent JSONL receipt per reduction
+  harnesstrim install omp [dir]            Install OMP tool_result hook (dry-run)
+                            --apply         Actually write the change
+                            --mode <m>      Bake mode: active|dryrun|off (env still wins)
+                            --min-length <n> Bake the min threshold (chars)
+                            --metrics <p>   Record a TrimEvent JSONL receipt per reduction
   harnesstrim uninstall <harness> [dir]    Remove only what install wrote (dry-run)
                             --apply         Actually write the change
   harnesstrim capabilities                 Print machine-readable per-harness capabilities (JSON)
@@ -139,10 +153,10 @@ async function main(argv: string[]): Promise<number> {
     }
     case "install": {
       const target = rest[0];
-      // Hermes uses the user-level Hermes home by default; other adapters keep
+      // Hermes and OMP use their user-level home by default; other adapters keep
       // their project-directory default. Pass an explicit directory for a
       // project-local or alternate-profile installation.
-      const dir = rest[1] ?? (target === "hermes" ? os.homedir() : process.cwd());
+      const dir = rest[1] ?? (target === "hermes" || target === "omp" ? os.homedir() : process.cwd());
       const apply = values.apply === true;
       const asJson = values.json === true;
       if (target === "opencode") {
@@ -190,23 +204,59 @@ async function main(argv: string[]): Promise<number> {
         return 0;
       }
       if (target === "hermes") {
-        const result = runInstallHermes(dir, apply);
+        const mode = parseModeFlag(values.mode);
+        if (mode === undefined && values.mode !== undefined) {
+          console.error(`Invalid --mode: ${values.mode} (expected active, dryrun, or off).`);
+          return 1;
+        }
+        const minLength = parseLengthFlag(values["min-length"]);
+        if (minLength === undefined && values["min-length"] !== undefined) {
+          console.error(`Invalid --min-length: ${values["min-length"]}`);
+          return 1;
+        }
+        const result = runInstallHermes(dir, apply, { mode, minLength });
         if (asJson) console.log(JSON.stringify(hermesInstallJson(result, apply), null, 2));
         else console.log(renderHermesInstall(result, apply));
         return 0;
       }
       if (target === "pi") {
-        const result = runInstallPi(dir, apply);
+        const mode = parseModeFlag(values.mode);
+        if (mode === undefined && values.mode !== undefined) {
+          console.error(`Invalid --mode: ${values.mode} (expected active, dryrun, or off).`);
+          return 1;
+        }
+        const minLength = parseLengthFlag(values["min-length"]);
+        if (minLength === undefined && values["min-length"] !== undefined) {
+          console.error(`Invalid --min-length: ${values["min-length"]}`);
+          return 1;
+        }
+        const result = runInstallPi(dir, apply, { mode, minLength, metrics: values.metrics });
         if (asJson) console.log(JSON.stringify(piInstallJson(result, apply), null, 2));
         else console.log(renderPiInstall(result, apply));
         return 0;
       }
-      console.error(`Unknown install target: ${target ?? "(none)"}. Supported: opencode, codex, claude, hermes, pi.`);
+      if (target === "omp") {
+        const mode = parseModeFlag(values.mode);
+        if (mode === undefined && values.mode !== undefined) {
+          console.error(`Invalid --mode: ${values.mode} (expected active, dryrun, or off).`);
+          return 1;
+        }
+        const minLength = parseLengthFlag(values["min-length"]);
+        if (minLength === undefined && values["min-length"] !== undefined) {
+          console.error(`Invalid --min-length: ${values["min-length"]}`);
+          return 1;
+        }
+        const result = runInstallOmp(dir, apply, { mode, minLength, metrics: values.metrics });
+        if (asJson) console.log(JSON.stringify(ompInstallJson(result, apply), null, 2));
+        else console.log(renderOmpInstall(result, apply));
+        return 0;
+      }
+      console.error(`Unknown install target: ${target ?? "(none)"}. Supported: opencode, codex, claude, hermes, pi, omp.`);
       return 1;
     }
     case "uninstall": {
       const target = rest[0];
-      const dir = rest[1] ?? (target === "hermes" ? os.homedir() : process.cwd());
+      const dir = rest[1] ?? (target === "hermes" || target === "omp" ? os.homedir() : process.cwd());
       const apply = values.apply === true;
       try {
         const result = runUninstall(target, dir, apply);
@@ -327,7 +377,8 @@ async function main(argv: string[]): Promise<number> {
       process.stdout.write(result.output);
       // --metrics <path>: append a TrimEvent per reduction, read by `harnesstrim metrics`.
       // Pass-throughs (attempted but unchanged) are recorded too, per HARNESSTRIM_TRACK_PASSTHROUGH
-      // (default on), so the metrics pass-through rate is meaningful.
+      // (default on), so the metrics pass-through rate is meaningful. This path is a standalone
+      // process (not inside a harness), so it also reports exact token counts (see tokens.ts).
       if (values.metrics) {
         try {
           const p = path.resolve(values.metrics);
@@ -343,6 +394,8 @@ async function main(argv: string[]): Promise<number> {
                   reducer: result.reducer,
                   beforeChars: result.beforeChars,
                   afterChars: result.afterChars,
+                  beforeTokens: countTokens(input),
+                  afterTokens: countTokens(result.output),
                 })
               ) + "\n"
             );
@@ -358,6 +411,8 @@ async function main(argv: string[]): Promise<number> {
                   beforeChars: input.length,
                   afterChars: input.length,
                   changed: false,
+                  beforeTokens: countTokens(input),
+                  afterTokens: countTokens(input),
                 })
               ) + "\n"
             );
@@ -377,7 +432,9 @@ async function main(argv: string[]): Promise<number> {
     case "mcp": {
       const { startStdioServer } = await import("@harnesstrim/mcp");
       // --metrics <path> records a TrimEvent per reduction (read with `harnesstrim metrics`).
-      await startStdioServer(values.metrics ? { metricsPath: values.metrics } : {});
+      // The MCP server is a standalone process (unlike harness adapters), so token counts
+      // are passed in for exact before/after token reporting (see tokens.ts).
+      await startStdioServer(values.metrics ? { metricsPath: values.metrics, countTokens } : { countTokens });
       // startStdioServer resolves once connected; keep the process alive for stdio.
       await new Promise<never>(() => {});
       return 0;
@@ -415,6 +472,13 @@ async function main(argv: string[]): Promise<number> {
 /** Parse `--mode` into the adapter's Mode union; undefined when unset or invalid. */
 function parseModeFlag(value: string | undefined): "active" | "dryrun" | "off" | undefined {
   return value === "active" || value === "dryrun" || value === "off" ? value : undefined;
+}
+
+/** Parse `--min-length` into a positive finite number; undefined when unset or invalid. */
+function parseLengthFlag(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
 }
 
 /** Split a comma-separated `--tools` value into trimmed tool names. */

--- a/packages/cli/src/digests.ts
+++ b/packages/cli/src/digests.ts
@@ -1,0 +1,129 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  REDUCE_INSTRUCTION_SNIPPET as CLAUDE_SNIPPET,
+  HOOK_COMMAND as CLAUDE_HOOK_COMMAND,
+  HOOK_MATCHER as CLAUDE_HOOK_MATCHER,
+} from "@harnesstrim/adapter-claude";
+import { REDUCE_INSTRUCTION_SNIPPET as CODEX_SNIPPET } from "@harnesstrim/adapter-codex";
+import { DEFAULT_HERMES_ADAPTER_CONFIG, bakeHermesConfig } from "@harnesstrim/adapter-hermes";
+import { DEFAULT_PI_ADAPTER_CONFIG, bakePiConfig } from "@harnesstrim/adapter-pi";
+import { DEFAULT_OMP_ADAPTER_CONFIG, bakeOmpConfig } from "@harnesstrim/adapter-omp";
+import {
+  buildOpencodeWrapper,
+  buildOpencodePackageJson,
+  DEFAULT_OPENCODE_ADAPTER_CONFIG,
+} from "./install.ts";
+import { resolveSkillsSourceDir, listShippedSkills } from "./skills-source.ts";
+import {
+  resolveHermesPluginSourceDir,
+  resolvePiExtensionSourceDir,
+  resolveOmpHookSourceDir,
+} from "./assets.ts";
+
+/**
+ * Per-artifact SHA-256 digests for `harnesstrim capabilities`.
+ *
+ * `writeSet` lists what `install <harness>` writes; `digests` pins the CONTENT this
+ * version would place there. A consumer (Token Harness, a CI gate, a second install
+ * site) hashes its copy and compares against this table instead of re-deriving or
+ * hardcoding a per-version table by hand — the `upstreamVersion: '0.0.7'` hand-pin
+ * use case. Only content this release fully owns is digested:
+ *   - shipped asset files (skill pack, Hermes plugin bundle, Pi extension, OMP hook)
+ *   - generated-but-deterministic files (OpenCode wrapper + package.json for the
+ *     default options, baked adapter config files)
+ *   - marker-guarded snippets (CLAUDE.md / AGENTS.md reduce-pipe instructions)
+ * Merged user files (settings.json, CLAUDE.md, AGENTS.md themselves) are NOT digested
+ * wholesale — only the owned fragment is, under a `(marker-guarded snippet)`-style key.
+ *
+ * Paths are relative to the install dir (project scope where scopes exist) and use
+ * forward slashes, so digests are portable across OSes.
+ */
+
+export type HarnessDigests = Record<string, string>;
+
+/** SHA-256 (hex) of a UTF-8 string or byte buffer. */
+export function sha256(content: string | Buffer): string {
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+function hashFile(p: string): string {
+  return sha256(fs.readFileSync(p));
+}
+
+/** Hash every file under `root` recursively, keyed by `<prefix>/<relpath>` (forward slashes). */
+function hashTree(root: string, prefix: string): HarnessDigests {
+  const out: HarnessDigests = {};
+  const walk = (dir: string, rel: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const relPath = rel ? `${rel}/${entry.name}` : entry.name;
+      const abs = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(abs, relPath);
+      else out[`${prefix}/${relPath}`] = hashFile(abs);
+    }
+  };
+  if (!fs.existsSync(root)) return out;
+  walk(root, "");
+  return out;
+}
+
+/** Digests for the shared skill pack, installed under `destRel` (claude/codex). */
+function skillDigests(destRel: string): HarnessDigests {
+  const sourceDir = resolveSkillsSourceDir();
+  const out: HarnessDigests = {};
+  for (const name of listShippedSkills(sourceDir)) {
+    Object.assign(out, hashTree(path.join(sourceDir, name), `${destRel}/${name}`));
+  }
+  return out;
+}
+
+const CLAUDE_HOOK_ENTRY = {
+  matcher: CLAUDE_HOOK_MATCHER,
+  hooks: [{ type: "command", command: CLAUDE_HOOK_COMMAND }],
+};
+
+/**
+ * Compute the digest tables for every harness in THIS version of the CLI. Resolves
+ * the shipped sources the installers read (same resolver as `install`, so the digest
+ * always matches the bytes an apply would place). Deterministic per version.
+ */
+export function computeHarnessDigests(): Record<string, HarnessDigests> {
+  const digests: Record<string, HarnessDigests> = {};
+
+  digests.opencode = {
+    ".opencode/plugin/harnesstrim.ts": sha256(buildOpencodeWrapper(DEFAULT_OPENCODE_ADAPTER_CONFIG)),
+    ".opencode/package.json": sha256(buildOpencodePackageJson(null)),
+  };
+
+  digests.codex = {
+    ...skillDigests(".codex/skills"),
+    "AGENTS.md (marker-guarded snippet)": sha256(CODEX_SNIPPET),
+  };
+
+  digests.claude = {
+    ...skillDigests(".claude/skills"),
+    "CLAUDE.md (marker-guarded snippet)": sha256(CLAUDE_SNIPPET),
+    ".claude/settings.json (hook entry)": sha256(JSON.stringify(CLAUDE_HOOK_ENTRY)),
+  };
+
+  digests.hermes = hashTree(
+    resolveHermesPluginSourceDir(),
+    ".hermes/plugins/harnesstrim"
+  );
+  digests.hermes[".hermes/plugins/harnesstrim/config.json"] = sha256(bakeHermesConfig(DEFAULT_HERMES_ADAPTER_CONFIG));
+
+  digests.pi = hashTree(
+    resolvePiExtensionSourceDir(),
+    ".pi/extensions/harnesstrim"
+  );
+  digests.pi[".pi/extensions/harnesstrim/config.json"] = sha256(bakePiConfig(DEFAULT_PI_ADAPTER_CONFIG));
+
+  digests.omp = hashTree(
+    resolveOmpHookSourceDir(),
+    ".omp/hooks/post"
+  );
+  digests.omp[".omp/hooks/harnesstrim.json"] = sha256(bakeOmpConfig(DEFAULT_OMP_ADAPTER_CONFIG));
+
+  return digests;
+}

--- a/packages/cli/src/install-hermes.ts
+++ b/packages/cli/src/install-hermes.ts
@@ -1,7 +1,15 @@
 import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
-import { HERMES_PLUGIN_NAME, markerFileContent, planHermesInstall, type HermesInstallPlan } from "@harnesstrim/adapter-hermes";
+import {
+  HERMES_PLUGIN_NAME,
+  markerFileContent,
+  planHermesInstall,
+  resolveHermesConfig,
+  bakeHermesConfig,
+  type HermesAdapterConfig,
+  type HermesInstallPlan,
+} from "@harnesstrim/adapter-hermes";
 import { resolveHermesPluginSourceDir } from "./assets.ts";
 
 export interface HermesInstallResult {
@@ -12,6 +20,17 @@ export interface HermesInstallResult {
   enabled: boolean | null;
   /** Diagnostic when Hermes CLI is unavailable or enable failed. */
   enableMessage?: string;
+  /** Absolute path of the baked config.json (mirrors the installed mode/min-length). */
+  configPath: string;
+  /** The resolved adapter config written to config.json. */
+  config: HermesAdapterConfig;
+}
+
+export interface HermesInstallOptions {
+  /** Bake the reduction mode into config.json (dryrun/active/off). */
+  mode?: HermesAdapterConfig["mode"];
+  /** Bake the minimum output length (chars) into config.json. */
+  minLength?: number;
 }
 
 function pluginDirExists(pluginDest: string): boolean {
@@ -30,16 +49,39 @@ function markerPresent(pluginDest: string): boolean {
   }
 }
 
+/** Read the existing baked config (null when absent/unparseable). */
+export function readHermesConfigFile(configPath: string): Partial<HermesAdapterConfig> | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(configPath, "utf8")) as Partial<HermesAdapterConfig>;
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Compute (and optionally apply) a Hermes plugin install: copy the shipped plugin
- * bundle into ``<installDir>/.hermes/plugins/harnesstrim/``.
+ * bundle into ``<installDir>/.hermes/plugins/harnesstrim/`` and bake the requested
+ * mode/min-length into ``config.json`` beside it.
  *
  * Dry-run by default (``apply=false``). When applied, always refresh the shipped
  * plugin files so an existing installation receives reducer and bug-fix updates.
+ * The baked config is preserved across refreshes unless explicit options are passed
+ * (re-running plain ``--apply`` never resets a user's ``--mode active``).
  */
-export function runInstallHermes(installDir: string, apply: boolean): HermesInstallResult {
+export function runInstallHermes(
+  installDir: string,
+  apply: boolean,
+  options: HermesInstallOptions = {}
+): HermesInstallResult {
   const pluginSourceDir = resolveHermesPluginSourceDir();
   const pluginDest = path.join(installDir, ".hermes", "plugins", "harnesstrim");
+  const configPath = path.join(pluginDest, "config.json");
+
+  const existingConfig = readHermesConfigFile(configPath);
+  // resolveHermesConfig keeps a baked state's values for any option not passed, so a
+  // plain `--apply` refreshes the bundle WITHOUT resetting a baked `--mode active`.
+  const config = resolveHermesConfig(existingConfig, options);
 
   const plan = planHermesInstall({
     installDir,
@@ -69,6 +111,9 @@ export function runInstallHermes(installDir: string, apply: boolean): HermesInst
     // Write the .installed marker
     fs.writeFileSync(path.join(pluginDest, ".installed"), markerFileContent());
     copiedFiles.push(".installed");
+    // Bake the adapter state (mode/min-length) into config.json.
+    fs.writeFileSync(configPath, bakeHermesConfig(config));
+    copiedFiles.push("config.json");
     applied = true;
 
     const enable = spawnSync("hermes", ["plugins", "enable", HERMES_PLUGIN_NAME], {
@@ -84,5 +129,5 @@ export function runInstallHermes(installDir: string, apply: boolean): HermesInst
     }
   }
 
-  return { plan, applied, copiedFiles, enabled, enableMessage };
+  return { plan, applied, copiedFiles, enabled, enableMessage, configPath, config };
 }

--- a/packages/cli/src/install-omp.test.ts
+++ b/packages/cli/src/install-omp.test.ts
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runInstallOmp, readOmpConfigFile } from "./install-omp.ts";
+import { OMP_HOOK_MARKER } from "@harnesstrim/adapter-omp";
+
+test("runInstallOmp --apply writes the hook and baked config", () => {
+  const project = fs.mkdtempSync(path.join(os.tmpdir(), "htrim-omp-install-"));
+  const result = runInstallOmp(project, true, { mode: "active", minLength: 300, metrics: "m.jsonl" });
+
+  assert.equal(result.applied, true);
+  const hook = path.join(project, ".omp", "hooks", "post", "harnesstrim.ts");
+  const config = path.join(project, ".omp", "hooks", "harnesstrim.json");
+  assert.ok(fs.existsSync(hook));
+  assert.match(fs.readFileSync(hook, "utf8"), new RegExp(OMP_HOOK_MARKER));
+  assert.ok(fs.existsSync(config));
+  const baked = readOmpConfigFile(config);
+  assert.deepEqual(baked, { mode: "active", minLength: 300, metrics: "m.jsonl" });
+});
+
+test("runInstallOmp --apply is idempotent and preserves the baked config", () => {
+  const project = fs.mkdtempSync(path.join(os.tmpdir(), "htrim-omp-install-"));
+  runInstallOmp(project, true, { mode: "active", minLength: 300 });
+
+  // A plain re-`--apply` (no options) must not reset the baked state.
+  const again = runInstallOmp(project, true);
+  assert.equal(again.plan.alreadyInstalled, true);
+  assert.deepEqual(readOmpConfigFile(again.configPath), { mode: "active", minLength: 300 });
+
+  // Explicit options override the baked state.
+  const overridden = runInstallOmp(project, true, { mode: "off" });
+  assert.equal(overridden.config.mode, "off");
+  assert.deepEqual(readOmpConfigFile(overridden.configPath), { mode: "off", minLength: 300 });
+});
+
+test("runInstallOmp dry-run writes nothing", () => {
+  const project = fs.mkdtempSync(path.join(os.tmpdir(), "htrim-omp-install-"));
+  const result = runInstallOmp(project, false, { mode: "active" });
+  assert.equal(result.applied, false);
+  assert.ok(!fs.existsSync(path.join(project, ".omp", "hooks", "post", "harnesstrim.ts")));
+  assert.ok(!fs.existsSync(path.join(project, ".omp", "hooks", "harnesstrim.json")));
+});

--- a/packages/cli/src/install-omp.ts
+++ b/packages/cli/src/install-omp.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  planOmpInstall,
+  resolveOmpConfig,
+  bakeOmpConfig,
+  OMP_HOOK_NAME,
+  OMP_CONFIG_NAME,
+  type OmpAdapterConfig,
+  type OmpInstallPlan,
+} from "@harnesstrim/adapter-omp";
+import { resolveOmpHookSourceDir } from "./assets.ts";
+
+export interface OmpInstallResult {
+  plan: OmpInstallPlan;
+  applied: boolean;
+  copiedFiles: string[];
+  /** Absolute path of the baked config.json (mode/min-length/metrics). */
+  configPath: string;
+  /** The resolved adapter config written to config.json. */
+  config: OmpAdapterConfig;
+}
+
+export interface OmpInstallOptions {
+  /** Bake the reduction mode into hooks/harnesstrim.json (dryrun/active/off). */
+  mode?: OmpAdapterConfig["mode"];
+  /** Bake the minimum output length (chars) into hooks/harnesstrim.json. */
+  minLength?: number;
+  /** Bake a TrimEvent JSONL receipt path so interception is verifiable. */
+  metrics?: string;
+}
+
+/** Read the existing baked config (null when absent/unparseable). */
+export function readOmpConfigFile(configPath: string): Partial<OmpAdapterConfig> | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(configPath, "utf8")) as Partial<OmpAdapterConfig>;
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Install the OMP tool_result hook: copy the shipped factory into the post hooks
+ * dir (`~/.omp/agent/hooks/post/` for user scope, `.omp/hooks/post/` for project)
+ * and bake mode/min-length/metrics into `harnesstrim.json` in the parent hooks dir
+ * (outside `post/` so omp's loader never treats it as a hook file). Dry-run by
+ * default; refresh-safe, and the baked config survives plain `--apply` re-runs.
+ */
+export function runInstallOmp(
+  installDir: string,
+  apply: boolean,
+  options: OmpInstallOptions = {}
+): OmpInstallResult {
+  const hookSourceDir = resolveOmpHookSourceDir();
+  const scope = path.resolve(installDir) === path.resolve(os.homedir()) ? "user" : "project";
+  const hooks = scope === "user"
+    ? path.join(installDir, ".omp", "agent", "hooks")
+    : path.join(installDir, ".omp", "hooks");
+  const hookDest = path.join(hooks, "post", OMP_HOOK_NAME);
+  const configPath = path.join(hooks, OMP_CONFIG_NAME);
+
+  const existingConfig = readOmpConfigFile(configPath);
+  const config = resolveOmpConfig(existingConfig, options);
+
+  const hookFileExists = fs.existsSync(hookDest);
+  const hookContent = hookFileExists ? fs.readFileSync(hookDest, "utf8") : null;
+
+  const plan = planOmpInstall({
+    installDir,
+    hookSourceDir,
+    hookFileExists,
+    hookContent,
+    scope,
+  });
+
+  const copiedFiles: string[] = [];
+  let applied = false;
+  if (apply) {
+    fs.mkdirSync(path.dirname(hookDest), { recursive: true });
+    fs.copyFileSync(path.join(hookSourceDir, OMP_HOOK_NAME), hookDest);
+    copiedFiles.push(path.join("post", OMP_HOOK_NAME));
+    fs.writeFileSync(configPath, bakeOmpConfig(config));
+    copiedFiles.push(OMP_CONFIG_NAME);
+    applied = true;
+  }
+
+  return { plan, applied, copiedFiles, configPath, config };
+}

--- a/packages/cli/src/install-pi.ts
+++ b/packages/cli/src/install-pi.ts
@@ -1,13 +1,33 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { planPiInstall, markerFileContent, type PiInstallPlan } from "@harnesstrim/adapter-pi";
+import {
+  planPiInstall,
+  markerFileContent,
+  resolvePiConfig,
+  bakePiConfig,
+  type PiAdapterConfig,
+  type PiInstallPlan,
+} from "@harnesstrim/adapter-pi";
 import { resolvePiExtensionSourceDir } from "./assets.ts";
 
 export interface PiInstallResult {
   plan: PiInstallPlan;
   applied: boolean;
   copiedFiles: string[];
+  /** Absolute path of the baked config.json (mode/min-length/metrics). */
+  configPath: string;
+  /** The resolved adapter config written to config.json. */
+  config: PiAdapterConfig;
+}
+
+export interface PiInstallOptions {
+  /** Bake the reduction mode into config.json (dryrun/active/off). */
+  mode?: PiAdapterConfig["mode"];
+  /** Bake the minimum output length (chars) into config.json. */
+  minLength?: number;
+  /** Bake a TrimEvent JSONL receipt path so interception is verifiable. */
+  metrics?: string;
 }
 
 function dirExists(p: string): boolean {
@@ -26,16 +46,37 @@ function markerPresent(dest: string): boolean {
   }
 }
 
+/** Read the existing baked config (null when absent/unparseable). */
+export function readPiConfigFile(configPath: string): Partial<PiAdapterConfig> | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(configPath, "utf8")) as Partial<PiAdapterConfig>;
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * `<installDir>/.pi/extensions/harnesstrim/`. Dry-run by default; `--apply` is
- * safe to repeat and refreshes the installed extension bundle.
+ * safe to repeat and refreshes the installed extension bundle. The baked
+ * config.json (mode/min-length/metrics) is preserved across refreshes unless
+ * explicit options are passed, so a plain re-`--apply` never resets a baked
+ * `--mode active`.
  */
-export function runInstallPi(installDir: string, apply: boolean): PiInstallResult {
+export function runInstallPi(
+  installDir: string,
+  apply: boolean,
+  options: PiInstallOptions = {}
+): PiInstallResult {
   const extensionSourceDir = resolvePiExtensionSourceDir();
   const scope = path.resolve(installDir) === path.resolve(os.homedir()) ? "user" : "project";
   const dest = scope === "user"
     ? path.join(installDir, ".pi", "agent", "extensions", "harnesstrim")
     : path.join(installDir, ".pi", "extensions", "harnesstrim");
+  const configPath = path.join(dest, "config.json");
+
+  const existingConfig = readPiConfigFile(configPath);
+  const config = resolvePiConfig(existingConfig, options);
 
   const plan = planPiInstall({
     installDir,
@@ -53,9 +94,11 @@ export function runInstallPi(installDir: string, apply: boolean): PiInstallResul
       .filter((entry) => entry.isFile())
       .map((entry) => entry.name);
     // Prune stale bundle files (e.g. a previous `harnesstrim.ts` entry) so the
-    // installed dir always mirrors the shipped bundle. Never touch `.installed`.
+    // installed dir always mirrors the shipped bundle. Never touch `.installed`
+    // or `config.json` (user-baked state we own but must preserve).
     for (const existing of fs.readdirSync(dest)) {
-      if (existing !== ".installed" && !sourceFiles.includes(existing)) {
+      if (existing === ".installed" || existing === "config.json") continue;
+      if (!sourceFiles.includes(existing)) {
         fs.rmSync(path.join(dest, existing), { recursive: true, force: true });
       }
     }
@@ -65,8 +108,12 @@ export function runInstallPi(installDir: string, apply: boolean): PiInstallResul
     }
     fs.writeFileSync(path.join(dest, ".installed"), markerFileContent());
     copiedFiles.push(".installed");
+    // Bake the adapter state (mode/min-length/metrics) — always (re)written so the
+    // file reflects the resolved config; content is unchanged when nothing changed.
+    fs.writeFileSync(configPath, bakePiConfig(config));
+    copiedFiles.push("config.json");
     applied = true;
   }
 
-  return { plan, applied, copiedFiles };
+  return { plan, applied, copiedFiles, configPath, config };
 }

--- a/packages/cli/src/json.ts
+++ b/packages/cli/src/json.ts
@@ -5,6 +5,7 @@ import type { CodexGlobalHookInstallResult, CodexInstallResult } from "./install
 import type { ClaudeInstallResult } from "./install-claude.ts";
 import type { PiInstallResult } from "./install-pi.ts";
 import type { HermesInstallResult } from "./install-hermes.ts";
+import type { OmpInstallResult } from "./install-omp.ts";
 
 /**
  * Machine-readable CLI output (the `--json` flag). Every command that accepts `--json`
@@ -163,7 +164,12 @@ export function hermesInstallJson(result: HermesInstallResult, apply: boolean): 
     alreadyInstalled: result.plan.alreadyInstalled,
     applied: result.applied,
     actions,
-    details: { enabled: result.enabled, enableMessage: result.enableMessage ?? null },
+    details: {
+      enabled: result.enabled,
+      enableMessage: result.enableMessage ?? null,
+      configPath: result.configPath,
+      config: result.config,
+    },
   };
 }
 
@@ -183,6 +189,33 @@ export function piInstallJson(result: PiInstallResult, apply: boolean): JsonInst
     alreadyInstalled: result.plan.alreadyInstalled,
     applied: result.applied,
     actions,
+    details: {
+      configPath: result.configPath,
+      config: result.config,
+    },
+  };
+}
+
+export function ompInstallJson(result: OmpInstallResult, apply: boolean): JsonInstallPlan {
+  const actions: JsonAction[] = [
+    {
+      type: result.plan.alreadyInstalled ? "none" : "copy",
+      path: result.plan.hookDest,
+      from: result.plan.hookSource,
+      note: result.plan.alreadyInstalled ? "already installed" : "copy OMP tool_result hook",
+    },
+  ];
+  return {
+    harness: "omp",
+    dryRun: !apply,
+    changed: !result.plan.alreadyInstalled,
+    alreadyInstalled: result.plan.alreadyInstalled,
+    applied: result.applied,
+    actions,
+    details: {
+      configPath: result.configPath,
+      config: result.config,
+    },
   };
 }
 

--- a/packages/cli/src/render.ts
+++ b/packages/cli/src/render.ts
@@ -6,6 +6,7 @@ import type { CodexGlobalHookInstallResult, CodexInstallResult } from "./install
 import type { ClaudeInstallResult } from "./install-claude.ts";
 import type { PiInstallResult } from "./install-pi.ts";
 import type { HermesInstallResult } from "./install-hermes.ts";
+import type { OmpInstallResult } from "./install-omp.ts";
 import type { UninstallResult } from "./uninstall.ts";
 
 const ICON: Record<Severity, string> = { warn: "!", info: "i", ok: "+" };
@@ -227,11 +228,12 @@ export function renderHermesInstall(result: HermesInstallResult, apply: boolean)
       lines.push(`  Enable manually: ${result.enableMessage}`);
     }
     lines.push("");
-    lines.push("Restart Hermes to load the refreshed plugin.");
+    lines.push(`  Baked config -> ${result.configPath} (mode ${result.config.mode}, min-length ${result.config.minLength})`);
+    lines.push("  Restart Hermes to load the refreshed plugin.");
   } else {
     lines.push(`  Source: ${plan.pluginSource}`);
     lines.push(`  Dest:   ${plan.pluginDest}`);
-    lines.push("  (plugin.yaml + __init__.py; plugin will be enabled on --apply when Hermes CLI is available)");
+    lines.push("  (plugin.yaml + __init__.py + config.json; plugin will be enabled on --apply when Hermes CLI is available)");
   }
 
   if (!apply) {
@@ -247,20 +249,48 @@ export function renderPiInstall(result: PiInstallResult, apply: boolean): string
   lines.push(`${apply ? "Installed" : "Would install"} Pi extension`);
   lines.push("");
 
-  if (plan.alreadyInstalled) {
-    lines.push(`Pi extension already installed at ${plan.extensionDest} (no change).`);
+  if (plan.alreadyInstalled && !apply) {
+    lines.push(`Pi extension already installed at ${plan.extensionDest}${" "}(no change).`);
   } else {
     lines.push(`Extension -> ${plan.extensionDest}`);
     if (apply) {
       lines.push(`  Copied: ${result.copiedFiles.join(", ")}`);
     } else {
       lines.push(`  Source: ${plan.extensionSource}`);
-      lines.push("  (index.ts + .installed marker)");
+      lines.push("  (index.ts + .installed marker + config.json)");
     }
     lines.push("");
     lines.push("The extension hooks Pi's `tool_result` and needs `harnesstrim` on PATH.");
-    lines.push("It starts in dry-run (logs to stderr); set HARNESSTRIM_MODE=active to reduce.");
   }
+  lines.push(`  Baked config -> ${result.configPath} (mode ${result.config.mode}, min-length ${result.config.minLength}${result.config.metrics ? `, metrics ${result.config.metrics}` : ""})`);
+
+  if (!apply) {
+    lines.push("");
+    lines.push("Dry run — nothing written. Re-run with `--apply`.");
+  }
+  return lines.join("\n");
+}
+
+export function renderOmpInstall(result: OmpInstallResult, apply: boolean): string {
+  const { plan } = result;
+  const lines: string[] = [];
+  lines.push(`${apply ? "Installed" : "Would install"} OMP tool_result hook`);
+  lines.push("");
+
+  if (plan.alreadyInstalled) {
+    lines.push(`OMP hook already installed at ${plan.hookDest} (no change).`);
+  } else {
+    lines.push(`Hook -> ${plan.hookDest}`);
+    if (apply) {
+      lines.push(`  Copied: ${result.copiedFiles.join(", ")}`);
+    } else {
+      lines.push(`  Source: ${plan.hookSource}`);
+      lines.push("  (harnesstrim.ts factory in hooks/post/ — discovered and loaded by omp with no");
+      lines.push("   settings.json entry and no trust gate)");
+    }
+  }
+  lines.push(`  Config -> ${plan.configDest} (mode ${result.config.mode}, min-length ${result.config.minLength}${result.config.metrics ? `, metrics ${result.config.metrics}` : ""})`);
+  lines.push("  The hook reduces text tool results via `harnesstrim reduce` and needs `harnesstrim` on PATH.");
 
   if (!apply) {
     lines.push("");

--- a/packages/cli/src/tokens.ts
+++ b/packages/cli/src/tokens.ts
@@ -1,0 +1,34 @@
+import { getEncoding } from "js-tiktoken";
+
+/**
+ * Token counting for `harnesstrim reduce` and `harnesstrim mcp`.
+ *
+ * These two paths are SEPARATE processes from any harness, so bundling a real
+ * tokenizer here does not violate the "no tokenizer inside the harness process"
+ * constraint (PLAN.md §2/§3): the OpenCode adapter, the Claude/Codex hooks and the
+ * Hermes/Pi/OMP plugins all run inside their harness and measure chars only. The
+ * pipe and the MCP server run standalone, so they can report exact token counts and
+ * make the pipe + MCP the two exact measures on Claude Code.
+ *
+ * cl100k_base matches the Tier A micro-benchmark tokenizer
+ * (benchmarks/src/tokenizer.ts) so telemetry and bench use one counting convention.
+ * Counts are a cross-model stand-in — exact per-vendor counts need that vendor's
+ * tokenizer (see PLAN.md §8). The tokenizer is initialized lazily and counts never
+ * throw: a tokenizer failure degrades to 0/omitted rather than breaking the pipe
+ * or the MCP server.
+ */
+let encoding: ReturnType<typeof getEncoding> | null = null;
+
+function encodingOnce(): ReturnType<typeof getEncoding> {
+  encoding ??= getEncoding("cl100k_base");
+  return encoding;
+}
+
+/** Token count of `text` using cl100k_base; 0 when the tokenizer cannot run. */
+export function countTokens(text: string): number {
+  try {
+    return encodingOnce().encode(text).length;
+  } catch {
+    return 0;
+  }
+}

--- a/packages/cli/src/uninstall.ts
+++ b/packages/cli/src/uninstall.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { HARNESSTRIM_MARKER as CLAUDE_MARKER } from "@harnesstrim/adapter-claude";
 import { HARNESSTRIM_MARKER as CODEX_MARKER } from "@harnesstrim/adapter-codex";
+import { OMP_HOOK_NAME, OMP_CONFIG_NAME, OMP_HOOK_MARKER } from "@harnesstrim/adapter-omp";
 import { OPENCODE_PLUGIN_NAME } from "./install.ts";
 import { listShippedSkills, resolveSkillsSourceDir } from "./skills-source.ts";
 
@@ -16,6 +17,7 @@ import { listShippedSkills, resolveSkillsSourceDir } from "./skills-source.ts";
  *    when our dependency was its only content).
  *  - hermes: the plugin dir (only when the .installed marker is present).
  *  - pi: the extension dir (only when the .installed marker is present).
+ *  - omp: the hook file (only when it carries our marker) + the baked config file.
  */
 
 export interface UninstallAction {
@@ -259,6 +261,33 @@ export function planPiUninstall(dir: string): UninstallPlan {
   return { harness: "pi", dir, changed: actions.length > 0, actions };
 }
 
+export function planOmpUninstall(dir: string): UninstallPlan {
+  const scope = path.resolve(dir) === path.resolve(process.env.HOME ?? "") ? "user" : "project";
+  const hooks =
+    scope === "user"
+      ? path.join(dir, ".omp", "agent", "hooks")
+      : path.join(dir, ".omp", "hooks");
+  const actions: UninstallAction[] = [];
+
+  const hookPath = path.join(hooks, "post", OMP_HOOK_NAME);
+  const hookContent = readOrNull(hookPath);
+  // Only a hook file carrying our marker is provably ours — never remove a same-named
+  // file the user (or another tool) wrote independently in the shared hooks dir.
+  if (hookContent !== null && hookContent.includes(OMP_HOOK_MARKER)) {
+    actions.push({ type: "remove-file", path: hookPath, note: "OMP tool_result hook installed by HarnessTrim" });
+  }
+
+  const configPath = path.join(hooks, OMP_CONFIG_NAME);
+  if (readOrNull(configPath) !== null) {
+    actions.push({
+      type: "remove-file",
+      path: configPath,
+      note: "baked harnesstrim.json (mode/min-length/metrics) installed by HarnessTrim",
+    });
+  }
+  return { harness: "omp", dir, changed: actions.length > 0, actions };
+}
+
 export function planUninstall(harness: string, dir: string): UninstallPlan {
   switch (harness) {
     case "claude":
@@ -271,8 +300,10 @@ export function planUninstall(harness: string, dir: string): UninstallPlan {
       return planHermesUninstall(dir);
     case "pi":
       return planPiUninstall(dir);
+    case "omp":
+      return planOmpUninstall(dir);
     default:
-      throw new Error(`Unknown uninstall target: ${harness}. Supported: opencode, codex, claude, hermes, pi.`);
+      throw new Error(`Unknown uninstall target: ${harness}. Supported: opencode, codex, claude, hermes, pi, omp.`);
   }
 }
 

--- a/packages/core/src/metrics/trim-event.ts
+++ b/packages/core/src/metrics/trim-event.ts
@@ -14,6 +14,11 @@ import { randomUUID } from "node:crypto";
  * `beforeTokens`/`afterTokens` are token counts ONLY where the emitting path has them
  * (`null` otherwise — no tokenizer is bundled into harness processes).
  *
+ * Token-count emitting paths (2026-08-04): the `reduce` pipe and the MCP server run as
+ * SEPARATE processes from any harness, so they bundle a cl100k tokenizer and report
+ * exact before/after tokens. In-harness emitters (OpenCode adapter, Claude/Codex hooks,
+ * Hermes/Pi/OMP plugins) keep measuring chars only and report `null` tokens.
+ *
  * v0.1.0 (2026-08-03): additive `changed` field. `changed: false` marks a recorded
  * pass-through (an attempted reduction that changed nothing) so `metrics` can report a
  * pass-through rate — the denominator for deciding which noisy-output classes still need

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -38,6 +38,25 @@ test("runReduceTool records a TrimEvent via the sink only when it reduces", () =
   assert.ok(e.afterChars < e.beforeChars);
 });
 
+test("runReduceTool reports exact token counts when a counter is provided", () => {
+  const events: Array<{ beforeTokens: number | null; afterTokens: number | null }> = [];
+  const sink = (e: unknown) => events.push(e as { beforeTokens: number | null; afterTokens: number | null });
+  const count = (s: string) => Math.ceil(s.length / 4);
+  runReduceTool(noisy, undefined, sink as never, true, count);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].beforeTokens, count(noisy));
+  assert.equal(events[0].afterTokens, count(textOf(runReduceTool(noisy, undefined, undefined, undefined, count).content)));
+});
+
+test("runReduceTool omits token counts without a counter (null, not fabricated)", () => {
+  const events: Array<{ beforeTokens: number | null; afterTokens: number | null }> = [];
+  const sink = (e: unknown) => events.push(e as { beforeTokens: number | null; afterTokens: number | null });
+  runReduceTool(noisy, undefined, sink as never);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].beforeTokens, null);
+  assert.equal(events[0].afterTokens, null);
+});
+
 test("MCP end-to-end: client lists and calls the reduce tool", async () => {
   const server = createServer();
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -10,6 +10,9 @@ import { reduceAuto, makeTrimEvent, DEFAULT_MIN_LENGTH, type TrimEvent } from "@
 export type Sink = (event: TrimEvent) => void;
 const noopSink: Sink = () => {};
 
+/** Counts tokens of a text; who provides it decides whether it may run here. */
+export type TokenCounter = (text: string) => number;
+
 /**
  * Append TrimEvents as JSONL to `metricsPath`. Best-effort: write failures are swallowed
  * so telemetry can never break the MCP tool. Must never write to stdout (reserved for the
@@ -33,12 +36,15 @@ export function createFileSink(metricsPath: string): Sink {
  * idempotent (inherited from core.reduceAuto), and never grows the input. When a `sink`
  * is provided and a reduction happens, records one TrimEvent; with `trackPassThrough`
  * (default true) it also records pass-through events for attempted-but-unchanged input.
+ * The MCP server is a standalone process (not inside a harness), so when `countTokens`
+ * is provided the events also carry exact before/after token counts.
  */
 export function runReduceTool(
   text: string,
   minLength?: number,
   sink: Sink = noopSink,
-  trackPassThrough = true
+  trackPassThrough = true,
+  countTokens?: TokenCounter
 ): CallToolResult {
   const result = reduceAuto(text, minLength);
   const threshold = minLength ?? DEFAULT_MIN_LENGTH;
@@ -50,6 +56,8 @@ export function runReduceTool(
         reducer: result.reducer,
         beforeChars: text.length,
         afterChars: result.output.length,
+        beforeTokens: countTokens ? countTokens(text) : undefined,
+        afterTokens: countTokens ? countTokens(result.output) : undefined,
       })
     );
   } else if (trackPassThrough && text.length >= threshold) {
@@ -61,6 +69,8 @@ export function runReduceTool(
         beforeChars: text.length,
         afterChars: text.length,
         changed: false,
+        beforeTokens: countTokens ? countTokens(text) : undefined,
+        afterTokens: countTokens ? countTokens(text) : undefined,
       })
     );
   }
@@ -78,6 +88,12 @@ export interface ServerOptions {
   metricsPath?: string;
   /** Record pass-through events too (default true when metricsPath is set). */
   trackPassThrough?: boolean;
+  /**
+   * Token counter for before/after token counts on emitted events. The MCP server
+   * runs OUTSIDE harness processes, so the CLI injects its cl100k tokenizer here;
+   * without it events report chars only (beforeTokens/afterTokens null).
+   */
+  countTokens?: TokenCounter;
 }
 
 /** Build the HarnessTrim MCP server with the `reduce` tool registered. */
@@ -98,7 +114,7 @@ export function createServer(options: ServerOptions = {}): McpServer {
           .describe("Skip reduction for inputs shorter than this many characters (default 400)"),
       },
     },
-    async ({ text, minLength }) => runReduceTool(text, minLength, sink, trackPassThrough)
+    async ({ text, minLength }) => runReduceTool(text, minLength, sink, trackPassThrough, options.countTokens)
   );
   return server;
 }
@@ -113,7 +129,7 @@ export async function startStdioServer(options: ServerOptions = {}): Promise<voi
   const envTrack = process.env.HARNESSTRIM_TRACK_PASSTHROUGH;
   const trackPassThrough =
     options.trackPassThrough ?? (envTrack !== undefined ? envTrack !== "0" && envTrack !== "false" : true);
-  const server = createServer({ metricsPath, trackPassThrough });
+  const server = createServer({ metricsPath, trackPassThrough, countTokens: options.countTokens });
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,8 @@ importers:
         specifier: workspace:*
         version: link:../core
 
+  packages/adapter-omp: {}
+
   packages/adapter-opencode:
     devDependencies:
       '@harnesstrim/core':
@@ -70,6 +72,9 @@ importers:
       '@harnesstrim/adapter-hermes':
         specifier: workspace:*
         version: link:../adapter-hermes
+      '@harnesstrim/adapter-omp':
+        specifier: workspace:*
+        version: link:../adapter-omp
       '@harnesstrim/adapter-pi':
         specifier: workspace:*
         version: link:../adapter-pi
@@ -85,6 +90,9 @@ importers:
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12
+      js-tiktoken:
+        specifier: ^1.0.15
+        version: 1.0.21
 
   packages/core: {}
 


### PR DESCRIPTION
## Summary

Implements the release-verification + adapter-expansion work on top of the metrics work in `feat/metrics-release-automation`:

1. **adapter-omp (new package)** — deterministic `tool_result` hook factory installed into `hooks/post/` (global `~/.omp/agent/hooks/post/` or project `.omp/hooks/post/`), marker-gated uninstall, config resolution/baking with env > config.json > defaults, install planner + unit tests.
2. **Install config baking** — `install hermes`/`install pi`/`install omp` gain `--mode`, `--min-length` (and `--metrics` for pi/omp) baked into each adapter's `config.json`/`harnesstrim.json`; refresh-safe and idempotent (plain re-`--apply` preserves baked state). Pi extension gained the `--metrics` TrimEvent JSONL receipt.
3. **Capability digests** — `harnesstrim capabilities` now emits per-artifact SHA-256 digests (`digests`) computed from the same shipped sources `install` reads, plus the `omp` harness entry. This is the release-verification table that replaces hand-pinned upstream versions.
4. **Exact token counts** — `reduce --metrics` and the MCP server are standalone processes, so their TrimEvents now carry `beforeTokens`/`afterTokens` (cl100k_base via js-tiktoken, inlined into the bundle — zero runtime deps preserved). In-harness adapters keep reporting `null` tokens, honoring the no-tokenizer-in-harness constraint.

## Verification

- `pnpm -r run typecheck` — clean on all 10 packages
- `pnpm -r run test` — 0 failures (new: adapter-omp suite, install-omp CLI tests, MCP token-count tests, digests tests)
- Tier A benchmark — verdict "fidelity OK", 76.6% token savings, 100% signal recall
- CLI rebuilt (`node packages/cli/build.mjs`) and smoke-tested manually: omp install/apply/idempotent-refresh/uninstall, hermes/pi config baking, digests output, token receipts (e.g. git-diff-slim 726→72 tokens)

## Notes

- OMP hook loading (no trust gate, no settings.json entry) is verified against the 17.2.4 binary docs/changelog, not a live `omp` session yet.
- `smoke-test.sh` extended: omp in the install loop, digests validation, baked-config preservation, token-receipt assertions.