### PR TITLE
ci: run the clean-package smoke test on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,28 @@ jobs:
       - name: Benchmark (fails if signal fidelity drops)
         run: pnpm run bench
 
+  # The same clean-package gate the release workflow runs, moved forward to every PR.
+  # It catches what `pnpm run test` structurally cannot: whether the published tarball
+  # works, and whether the assertions in smoke-test.sh still match real CLI output.
+  # Running it only at release meant a broken assertion could sit on main until a tag.
+  # ubuntu only, matching the release job — the script is bash/POSIX (mktemp, timeout,
+  # an executable node_modules/.bin entry).
+  smoke:
+    name: clean-package smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: CLI build
+        run: node packages/cli/build.mjs
+      - name: Clean-package smoke test (npm pack -> fresh install)
+        run: bash packages/cli/smoke-test.sh
+
   hermes-plugin:
     name: hermes python plugin
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

`smoke-test.sh` only ran in the release workflow, so it guarded a tag rather than a change.

That gap is why #11 landed on main with token-count assertions that could never match the real receipt format — receipts are compact JSONL (`"beforeTokens":727`), the assertions grepped for `"beforeTokens": 727`. CI was green; the failure would have surfaced when cutting the next release, as a broken release rather than a failed PR.

Adds a `smoke` job that mirrors the release gate: install, `node packages/cli/build.mjs`, `bash packages/cli/smoke-test.sh`.

It covers what `pnpm run test` structurally cannot:

- whether the packed tarball actually works from a fresh install (the source-layout assumptions in `assets.ts` / `build.mjs` — a package that works from a checkout but breaks from the tarball passes every unit test)
- whether the assertions in `smoke-test.sh` still match real CLI output

## Notes

- **ubuntu only**, matching the release job. The script is bash/POSIX: `mktemp -d`, `timeout`, and an executable `node_modules/.bin/harnesstrim`. Making it run on `windows-latest` is a separate piece of work, and the release gate it mirrors is ubuntu-only anyway.
- Runs as its own job rather than a step in the `build` matrix, so it executes in parallel and doesn't triple the `npm pack` + fresh-install cost across three OSes.
- The release workflow keeps its own copy of the gate: a tag build must not depend on CI having run that particular commit.

## Verification

This PR is its own test — the `clean-package smoke test` job appears in the checks below and must pass. Confirmed locally that the script exits 0 end-to-end on the current main (`== smoke: ALL CHECKS PASSED ==`), and that it exits non-zero when an assertion is wrong (that is how the #11 defect was found).
