### PR TITLE
fix: let explicit telemetry options override environment

### DIFF
--- a/packages/adapter-opencode/src/config.ts
+++ b/packages/adapter-opencode/src/config.ts
@@ -70,7 +70,9 @@ export function resolveConfig(options: Record<string, unknown> = {}): AdapterCon
   const toolFilter = parseToolFilter(options.toolFilter) ?? parseToolFilter(env.HARNESSTRIM_TOOLS);
 
   const telemetry =
-    options.telemetry === true || env.HARNESSTRIM_TELEMETRY === "1" || env.HARNESSTRIM_TELEMETRY === "true";
+    typeof options.telemetry === "boolean"
+      ? options.telemetry
+      : env.HARNESSTRIM_TELEMETRY === "1" || env.HARNESSTRIM_TELEMETRY === "true";
   const telemetryPath =
     (typeof options.telemetryPath === "string" ? options.telemetryPath : undefined) ??
     env.HARNESSTRIM_TELEMETRY_PATH ??

--- a/packages/adapter-opencode/src/plugin.test.ts
+++ b/packages/adapter-opencode/src/plugin.test.ts
@@ -84,7 +84,7 @@ test("telemetry: appends a TrimEvent when enabled", async () => {
 test("telemetry: off by default writes nothing", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "htrim-telemetry-"));
   const telemetryPath = path.join(dir, "metrics.jsonl");
-  const hooks = await HarnessTrim(noopInput, { mode: "active", telemetryPath });
+  const hooks = await HarnessTrim(noopInput, { mode: "active", telemetry: false, telemetryPath });
   const { input, output } = afterArgs(noisyTestOutput);
   await hooks["tool.execute.after"]!(input, output);
   assert.equal(fs.existsSync(telemetryPath), false);


### PR DESCRIPTION
## Summary
- make an explicit boolean `telemetry` option take precedence over `HARNESSTRIM_TELEMETRY`
- keep environment configuration as the fallback when the option is omitted
- add a regression assertion for telemetry-disabled plugin instances

## Verification
- `pnpm --filter @harnesstrim/adapter-opencode test` (12/12)
- `pnpm run typecheck`
- `pnpm run test`

## Environment
- Zorin OS 18.1 (Ubuntu 24.04-based)
- Linux 7.0.0-28-generic, x86_64
- Node.js v24.13.0
- pnpm 10.33.4
