### PR TITLE
fix(cli): distinguish disk install from gateway load on hermes install --apply

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -373,8 +373,30 @@ multi-tool Tier B evidence are all repeatable.
 ## 10. Status log
 
 
+- **2026-08-06** — **PR #15 merged + issue #14 closed (Hermes reload verification).**
+  - **PR #15 (`fix: let explicit telemetry options override environment`)** was originally
+    CONFLICTING because its branch carried the already-merged #11 commit plus the real delta, a single
+    fix commit. The fix: `resolveConfig()` in the OpenCode adapter now honors an explicit
+    `telemetry: false` option over `HARNESSTRIM_TELEMETRY` env (before, env=true won even when the
+    plugin option said false). Also made the "telemetry off" adapter test set `telemetry: false`
+    explicitly. Rebased the fix onto `main` (it applied cleanly against `5453779`), updated the fork
+    branch, and merged — **MERGEABLE + typecheck + 60 cli tests green**.
+  - **Issue #14 closed (Hermes `install --apply` runtime reload).** Reported that after a plugin
+    refresh the files on disk are new but the running gateway keeps the previous bundle, with no
+    clear guidance. Chose the "post-install verification" path (no abrupt gateway restart, no
+    guessed commands): after `--apply` + `hermes plugins enable`, the installer now also runs
+    `hermes plugins list` (read-only) and reports whether Hermes recognizes the plugin on disk
+    (`pluginListed`) — explicitly NOT a proof the running gateway loaded the new bundle (Hermes loads
+    plugins at gateway startup). Render + `--json` surface the distinction and direct the user to run
+    `hermes gateway restart` (or `systemctl --user restart hermes-gateway`) from a shell OUTSIDE the
+    gateway process. Parser extracted as a pure unit-tested function (`hermesPluginListed`); dry-run
+    still verifies nothing, defaulting to `null` when the Hermes CLI is unavailable. 3 new tests,
+    typecheck clean, READMEs (root + adapter-hermes) updated. Fueled by real dogfooding telemetry
+    (repo `.harnesstrim/metrics.jsonl`, 39 events) which surfaced that large pass-throughs were all
+    by-design (source diffs / cat / gh metadata), leaving only GitHub CI logs as a candidate for a
+    future `ci-log-slim` reducer.
+
 - **2026-08-03** — **v0.1.0 implemented (metrics depth + release CI), CLI bumped to 0.1.0, publish
-  still user-gated.** What landed:
   - **`harnesstrim metrics` depth (the "trustworthy measurement" half).** `summarize()` now reports
     `byHarness` (per-harness savings, sorted desc), attempt accounting (`reduced` / `passThrough` /
     `passThroughRate`) and `reductionErrors` + `grewChars` for attempts marked changed that grew the

--- a/README.md
+++ b/README.md
@@ -490,11 +490,15 @@ harnesstrim install hermes --apply                    # ~/.hermes/plugins/harnes
 harnesstrim install hermes /path/to/project --apply   # project-local .hermes/plugins/
 ```
 
-`install hermes --apply` refreshes the Python plugin, then enables it with `hermes plugins enable harnesstrim`
-when the Hermes CLI is available. The no-argument form targets the user-level Hermes home; pass an
-explicit directory only for a project-local or alternate-profile installation.
+`install hermes --apply` refreshes the Python plugin, enables it with `hermes plugins enable harnesstrim`
+when the Hermes CLI is available, and verifies recognition via `hermes plugins list` — reporting
+"on disk" separately from "loaded by the running gateway". The no-argument form targets the user-level
+Hermes home; pass an explicit directory only for a project-local or alternate-profile installation.
 
-Restart Hermes after installation. It starts in `dryrun`; set `HARNESSTRIM_MODE=active` to reduce and
+Hermes loads plugin bundles at gateway startup, so after a refresh run `hermes gateway restart` (or
+`systemctl --user restart hermes-gateway`) from a shell **outside** the gateway process — a gateway
+cannot safely replace itself from inside an active agent turn. It starts in `dryrun`; set
+`HARNESSTRIM_MODE=active` to reduce and
 `HARNESSTRIM_TELEMETRY=1` to record metrics. The plugin handles `terminal`, `read_file`, `web_extract`,
 `search_files`, `browser_snapshot`, and `vision_analyze`, preserving each tool's result schema. Run
 `harnesstrim metrics` to read the active Hermes profile's telemetry. It detects test output, git diffs,

--- a/packages/adapter-hermes/README.md
+++ b/packages/adapter-hermes/README.md
@@ -18,8 +18,12 @@ harnesstrim install hermes --apply                  # copies/refreshes and enabl
 harnesstrim install hermes /path/to/project --apply # explicit project-local .hermes target
 ```
 
-`--apply` invokes `hermes plugins enable harnesstrim` after copying when the Hermes CLI is available.
-Restart Hermes after installation or refresh so the gateway loads the current plugin bundle.
+`--apply` invokes `hermes plugins enable harnesstrim` after copying when the Hermes CLI is available,
+then runs `hermes plugins list` to verify the plugin is recognized on disk. Hermes loads plugin bundles
+at **gateway startup**, so a refreshed bundle is only active after the running gateway is restarted.
+`install` therefore prints guidance to reload the gateway with `hermes gateway restart` (or
+`systemctl --user restart hermes-gateway`) from a shell **outside** the gateway process — a gateway
+cannot safely replace itself from inside an active agent turn (Hermes self-restart protection).
 
 ## Mode lifecycle
 

--- a/packages/cli/src/install-hermes.test.ts
+++ b/packages/cli/src/install-hermes.test.ts
@@ -1,0 +1,36 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runInstallHermes, hermesPluginListed } from "./install-hermes.ts";
+import { HERMES_PLUGIN_NAME } from "@harnesstrim/adapter-hermes";
+
+function tmpProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "htrim-hermes-"));
+}
+
+test("hermesPluginListed finds the plugin in hermes plugins list output of any layout", () => {
+  assert.equal(hermesPluginListed(`✓ ${HERMES_PLUGIN_NAME}\t enabled`), true);
+  assert.equal(hermesPluginListed(`${HERMES_PLUGIN_NAME}  enabled`), true);
+  assert.equal(hermesPluginListed("security-guidance\tdisabled\nrich-messages-html  disabled"), false);
+  assert.equal(hermesPluginListed(""), false);
+});
+
+test("runInstallHermes --apply copies the bundle and bakes config", () => {
+  const project = tmpProject();
+  const result = runInstallHermes(project, true, { mode: "dryrun", minLength: 300 });
+  assert.equal(result.applied, true);
+  assert.ok(result.copiedFiles.includes(".installed"));
+  assert.ok(result.copiedFiles.includes("config.json"));
+  const pluginDest = result.plan.pluginDest;
+  assert.ok(fs.existsSync(path.join(pluginDest, ".installed")));
+  assert.deepEqual(result.config, { mode: "dryrun", minLength: 300 });
+});
+
+test("runInstallHermes dry-run writes nothing", () => {
+  const project = tmpProject();
+  const result = runInstallHermes(project, false, { mode: "active" });
+  assert.equal(result.applied, false);
+  assert.ok(!fs.existsSync(path.join(project, ".hermes", "plugins")));
+});

--- a/packages/cli/src/install-hermes.ts
+++ b/packages/cli/src/install-hermes.ts
@@ -20,6 +20,15 @@ export interface HermesInstallResult {
   enabled: boolean | null;
   /** Diagnostic when Hermes CLI is unavailable or enable failed. */
   enableMessage?: string;
+  /**
+   * Post-enable recognition: whether the freshly installed plugin appears in
+   * `hermes plugins list` output. `"listed"` means the Hermes CLI can see the
+   * plugin on disk; `"absent"` means enable ran but the plugin is not listed;
+   * `null` means the CLI was unavailable or `plugins list` could not run (e.g.
+   * it was reached from inside the running gateway). This is NOT a proof that
+   * the running gateway has loaded the new bundle — that happens at restart.
+   */
+  pluginListed: boolean | null;
   /** Absolute path of the baked config.json (mirrors the installed mode/min-length). */
   configPath: string;
   /** The resolved adapter config written to config.json. */
@@ -129,5 +138,38 @@ export function runInstallHermes(
     }
   }
 
-  return { plan, applied, copiedFiles, enabled, enableMessage, configPath, config };
+  // Post-enable recognition check: does the Hermes CLI now see the plugin on disk?
+  // `hermes plugins list` is a local, read-only command — safe to run after an apply.
+  // This tells "installed + recognized" apart from "loaded by the running gateway":
+  // Hermes loads plugin bundles at gateway startup, so a healthy list result does NOT
+  // mean the active gateway has picked up the new bundle yet (that needs a restart).
+  const pluginListed = apply ? checkHermesPluginListed() : null;
+
+  return { plan, applied, copiedFiles, enabled, enableMessage, pluginListed, configPath, config };
+}
+
+/**
+ * Parser for `hermes plugins list` output: report whether the harnesstrim plugin is
+ * recognized. Tolerant to column layout — just looks for the plugin name. Pure, so
+ * the recognition logic is unit-testable without a Hermes CLI.
+ */
+export function hermesPluginListed(output: string): boolean {
+  if (!output) return false;
+  return new RegExp(HERMES_PLUGIN_NAME, "i").test(output);
+}
+
+/**
+ * Run `hermes plugins list` and report whether `harnesstrim` is recognized. Returns
+ * `null` when the Hermes CLI is unavailable or the command errors (e.g. it cannot run
+ * from inside the active gateway). Never throws.
+ */
+export function checkHermesPluginListed(): boolean | null {
+  try {
+    const list = spawnSync("hermes", ["plugins", "list"], { encoding: "utf8", timeout: 30_000 });
+    if (list.error) return null;
+    if (list.status !== 0) return null;
+    return hermesPluginListed(`${list.stdout}\n${list.stderr}`);
+  } catch {
+    return null;
+  }
 }

--- a/packages/cli/src/json.ts
+++ b/packages/cli/src/json.ts
@@ -167,6 +167,7 @@ export function hermesInstallJson(result: HermesInstallResult, apply: boolean): 
     details: {
       enabled: result.enabled,
       enableMessage: result.enableMessage ?? null,
+      pluginListed: result.pluginListed ?? null,
       configPath: result.configPath,
       config: result.config,
     },

--- a/packages/cli/src/render.ts
+++ b/packages/cli/src/render.ts
@@ -229,7 +229,19 @@ export function renderHermesInstall(result: HermesInstallResult, apply: boolean)
     }
     lines.push("");
     lines.push(`  Baked config -> ${result.configPath} (mode ${result.config.mode}, min-length ${result.config.minLength})`);
-    lines.push("  Restart Hermes to load the refreshed plugin.");
+    // Distinguish "recognized on disk" from "loaded by the running gateway". Hermes
+    // loads plugin bundles at gateway startup, so a fresh bundle is only active after
+    // the gateway process restarts — and a gateway must not replace itself from inside
+    // an active agent turn (Hermes self-restart protection, systemd-managed instances).
+    if (result.pluginListed === true) {
+      lines.push("  Hermes CLI sees the plugin on disk (hermes plugins list).");
+      lines.push("  The RUNNING gateway still uses the previous bundle until it is restarted.");
+    } else if (result.pluginListed === null) {
+      lines.push("  Could not verify via `hermes plugins list` (CLI unavailable or ran from inside the gateway).");
+    }
+    lines.push("  Reload: run `hermes gateway restart` from a shell OUTSIDE the gateway.");
+    lines.push("  (or for systemd instances: `systemctl --user restart hermes-gateway`); a reload");
+    lines.push("  may be deferred to the supervisor after the current run.");
   } else {
     lines.push(`  Source: ${plan.pluginSource}`);
     lines.push(`  Dest:   ${plan.pluginDest}`);


### PR DESCRIPTION
Closes #14.

## The gap

`install hermes --apply` refreshes the plugin on disk and enables it, then prints
`Restart Hermes to load the refreshed plugin.` — and stops there. Hermes loads plugin
bundles at **gateway startup**, so until the gateway restarts the files are new but the
running process still serves the previous bundle. Nothing in the output distinguishes
those two states, which is exactly the confusing situation reported in #14.

## The approach

Of the four options in the issue I took the verification path (#4), plus the
in-gateway explanation (#3). Automating a restart is the wrong move here: a gateway must
not replace itself from inside an active agent turn, Hermes self-restart protection
blocks it anyway, and guessing the supervisor's restart command (`systemd --user` vs.
something else) is not something the installer can do safely.

So the installer now reports what it can actually verify, and is explicit about what it
cannot:

- after `hermes plugins enable`, run the read-only `hermes plugins list` and record
  whether Hermes recognizes the plugin on disk as `pluginListed`. It is `null` when the
  CLI is unavailable or the command fails — including when it is reached from inside the
  active gateway — and dry-run verifies nothing at all;
- the rendered output says plainly that the **running** gateway still uses the previous
  bundle, and points at `hermes gateway restart` (or
  `systemctl --user restart hermes-gateway`) from a shell **outside** the gateway, noting
  the reload may be deferred to the supervisor after the current run;
- `--json` carries `pluginListed` so a supervisor or script can act on it.

`pluginListed: true` deliberately does not claim the gateway loaded anything — the
docstring and the printed text both say so.

## Notes

- The list parser is extracted as a pure `hermesPluginListed()`, tolerant to column
  layout, so recognition logic is unit-testable without a Hermes CLI installed.
- No abrupt gateway termination, and active sessions are untouched.
- READMEs (root + `adapter-hermes`) now explain the install/reload lifecycle instead of a
  bare "restart Hermes".

## Verification

- 3 new tests in `packages/cli/src/install-hermes.test.ts` (parser layouts, `--apply`
  copy + baked config, dry-run writes nothing).
- `pnpm typecheck` clean across all packages.
- `pnpm test`: 204 passing, 0 failing.
