### PR TITLE
feat: make reducers fail-open and gate runtime integrity

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -352,6 +352,13 @@ telemetry and preserve benchmark signal recall.
 
 **Goal:** demonstrate savings across real multi-tool coding tasks without degrading task outcomes.
 
+**Reducer-runtime hardening:** the shared in-process dispatcher is fail-open: a reducer exception
+passes the original payload through byte-for-byte and exposes failure metadata instead of breaking
+the harness. Tier A is also promoted from a reduction/fidelity check to a release gate over four
+properties: 100% signal recall/audit, deterministic output, idempotent second pass, and p95 reducer
+latency ≤ 25 ms on every fixed fixture. This borrows the useful operational discipline of local
+token-optimizer products without introducing a mandatory proxy/daemon or another network hop.
+
 - Expand Tier B to multi-tool tasks, multiple output volumes, and repeated runs on fixed model
   versions. Report fresh input, cache reads, total billed tokens, success rate, and failure modes
   separately.

--- a/README.md
+++ b/README.md
@@ -181,8 +181,10 @@ with **signal fidelity**, **determinism**, **idempotency**, and **p95 local late
 that must survive (the error, the failing test, the assertion, the changed files, the summary), it
 measures how many are kept and audits any dropped line that looks like signal. The latency budget is
 25 ms p95 per fixed fixture, with warm-up and repeated measurements to avoid treating one scheduler
-spike as a regression. Headline reduction/fidelity from the seed fixtures remains: **−63% tokens at 100% signal recall** across the seed fixtures (`pnpm run bench`,
-no LLM). The bench fails loudly if signal recall drops below 100% or a signal-looking line is dropped.
+spike as a regression. Current Tier A headline: **−76.6% tokens at 100% signal recall** across the
+seven fixed fixtures (`pnpm run bench`, no LLM), including the lint-warning reducer added after the
+original six-fixture baseline. The bench fails loudly if fidelity, determinism, idempotency, or the
+latency budget regresses.
 
   | Fixture | Reducer | Tokens | Reduction | Signal kept |
   | --- | --- | --- | --- | --- |
@@ -192,7 +194,8 @@ no LLM). The bench fails loudly if signal recall drops below 100% or a signal-lo
   | JSON API array | json-output-slim | 527 → 140 | −73.4% | 3/3 |
   | file listing (long) | file-listing-slim | 508 → 190 | −62.6% | 3/3 |
   | daily briefing (prose) | generic-text-slim | 196 → 150 | −23.5% | 3/3 |
-  | **Measured blend** | | 2973 → 1090 | **−63.3%** | **24/24 (100%)** |
+  | eslint warning wall | lint-output-slim | 2221 → 127 | −94.3% | 5/5 |
+  | **Measured blend** | | 5194 → 1217 | **−76.6%** | **29/29 (100%)** |
 
 Each fixture's must-keep lines are annotated in [`benchmarks/src/run.ts`](benchmarks/src/run.ts), so
 "what survives" is explicit and reproducible, not a claim.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ flowchart TB
 
 The adapter intercepts tool results, the shared core decides what (if anything) to slim, and only the
 signal reaches the model. Reducers are **deterministic and idempotent** and never touch the cacheable
-prompt prefix — so they shrink cost without busting the prompt cache.
+prompt prefix — so they shrink cost without busting the prompt cache. The shared dispatcher is
+also **fail-open**: if a matched reducer throws, HarnessTrim returns the original tool output
+byte-for-byte instead of turning an optimization failure into a harness failure.
 
 ```mermaid
 sequenceDiagram
@@ -163,8 +165,9 @@ What HarnessTrim optimizes for, and how each is measured:
 | **Blended session reduction** | total tokens saved / baseline session tokens | 30–50% (model) | end-to-end benchmark (Tier B, planned) |
 | **Quality retention** | task-success parity vs the untrimmed baseline | 100% (no regressions) | Tier B benchmark |
 | **Cache preservation** | share of reductions that leave the cacheable prefix untouched | 100% | design guarantee (reducers only touch volatile output) |
+| **Reducer stability** | same input produces the same output; reducing an already-reduced output is a no-op | 100% deterministic + idempotent | Tier A benchmark, release gate |
 | **Coverage** | share of noisy tool calls that a reducer actually matched | grow over time | telemetry (`reducer: null` = missed) |
-| **Overhead** | added latency / tokens from the stack itself | negligible | reducers run locally, no tokenizer in-process |
+| **Overhead** | reducer execution latency | p95 ≤ 25 ms per Tier A fixture | Tier A benchmark, release gate |
 
 ## Savings: measured vs hypothesized
 
@@ -173,10 +176,12 @@ Two honesty tiers. Keep them separate.
 ### Measured (real numbers today)
 
 The token number alone is not the point — a reducer that drops the one line you needed would post a
-great percentage and ruin the context. So the benchmark measures **both**: token reduction *and*
-**signal fidelity** — of the lines that must survive (the error, the failing test, the assertion, the
-changed files, the summary), how many are kept. It also **audits** any dropped line that looks like
-signal. Headline: **−63% tokens at 100% signal recall** across the seed fixtures (`pnpm run bench`,
+great percentage and ruin the context. So the Tier A release gate measures token reduction together
+with **signal fidelity**, **determinism**, **idempotency**, and **p95 local latency**. Of the lines
+that must survive (the error, the failing test, the assertion, the changed files, the summary), it
+measures how many are kept and audits any dropped line that looks like signal. The latency budget is
+25 ms p95 per fixed fixture, with warm-up and repeated measurements to avoid treating one scheduler
+spike as a regression. Headline reduction/fidelity from the seed fixtures remains: **−63% tokens at 100% signal recall** across the seed fixtures (`pnpm run bench`,
 no LLM). The bench fails loudly if signal recall drops below 100% or a signal-looking line is dropped.
 
   | Fixture | Reducer | Tokens | Reduction | Signal kept |

--- a/benchmarks/src/run.ts
+++ b/benchmarks/src/run.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath, pathToFileURL } from "node:url";
 import path from "node:path";
 import fs from "node:fs";
+import { performance } from "node:perf_hooks";
 import {
   fileListingSlim,
   genericTextSlim,
@@ -15,6 +16,15 @@ import { countTokens } from "./tokenizer.ts";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixturesDir = path.resolve(__dirname, "../fixtures");
 const reportPath = path.resolve(__dirname, "../reports/latest.json");
+
+const BENCH_WARMUP_ITERATIONS = 10;
+const BENCH_MEASURED_ITERATIONS = 100;
+/**
+ * Local reducers should be effectively invisible beside a harness/model round trip. p95 rather
+ * than max avoids making CI scheduling jitter a product regression while still catching runaway
+ * regex/algorithm changes.
+ */
+const LATENCY_P95_BUDGET_MS = 25;
 
 interface Fixture {
   file: string;
@@ -105,6 +115,12 @@ export interface BenchRow {
   mustKeepTotal: number;
   mustKeepKept: number;
   droppedSignalLines: string[];
+  deterministic: boolean;
+  idempotent: boolean;
+  latencyMedianMs: number;
+  latencyP95Ms: number;
+  latencyBudgetMs: number;
+  latencyOk: boolean;
 }
 
 export interface BenchReport {
@@ -118,11 +134,65 @@ export interface BenchReport {
   droppedSignalLines: number;
   /** True when every must-keep line survived and no signal-looking line was dropped. */
   fidelityOk: boolean;
+  determinismOk: boolean;
+  idempotencyOk: boolean;
+  latencyOk: boolean;
+  maxLatencyP95Ms: number;
+  /** Release gate: savings count only when fidelity, stability and local overhead all hold. */
+  integrityOk: boolean;
 }
 
 function pct(before: number, after: number): number {
   if (before === 0) return 0;
   return Math.round((1 - after / before) * 1000) / 10;
+}
+
+function roundMs(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function percentile(sorted: readonly number[], fraction: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.max(0, Math.min(sorted.length - 1, Math.ceil(sorted.length * fraction) - 1));
+  return sorted[index] ?? 0;
+}
+
+function measureReducer(reducer: Reducer, raw: string): {
+  deterministic: boolean;
+  idempotent: boolean;
+  latencyMedianMs: number;
+  latencyP95Ms: number;
+  latencyOk: boolean;
+} {
+  for (let iteration = 0; iteration < BENCH_WARMUP_ITERATIONS; iteration += 1) {
+    reducer.reduce(raw);
+  }
+
+  const baseline = reducer.reduce(raw);
+  const signature = JSON.stringify(baseline);
+  let deterministic = true;
+  const durations: number[] = [];
+
+  for (let iteration = 0; iteration < BENCH_MEASURED_ITERATIONS; iteration += 1) {
+    const started = performance.now();
+    const result = reducer.reduce(raw);
+    durations.push(performance.now() - started);
+    if (JSON.stringify(result) !== signature) deterministic = false;
+  }
+
+  const secondPass = reducer.reduce(baseline.output);
+  const idempotent = secondPass.output === baseline.output && secondPass.changed === false;
+  durations.sort((left, right) => left - right);
+  const latencyMedianMs = roundMs(percentile(durations, 0.5));
+  const latencyP95Ms = roundMs(percentile(durations, 0.95));
+
+  return {
+    deterministic,
+    idempotent,
+    latencyMedianMs,
+    latencyP95Ms,
+    latencyOk: latencyP95Ms <= LATENCY_P95_BUDGET_MS,
+  };
 }
 
 function auditDroppedSignal(raw: string, reduced: string): string[] {
@@ -149,6 +219,7 @@ export function runBench(): BenchReport {
     const beforeTokens = countTokens(raw);
     const afterTokens = countTokens(result.output);
     const mustKeepKept = mustKeep.filter((s) => result.output.includes(s)).length;
+    const stability = measureReducer(reducer, raw);
     return {
       fixture: file,
       reducer: reducer.name,
@@ -160,13 +231,15 @@ export function runBench(): BenchReport {
       mustKeepTotal: mustKeep.length,
       mustKeepKept,
       droppedSignalLines: auditDroppedSignal(raw, result.output),
+      ...stability,
+      latencyBudgetMs: LATENCY_P95_BUDGET_MS,
     };
   });
 
   for (const row of rows) {
     const recall = row.mustKeepTotal === 0 ? 100 : Math.round((row.mustKeepKept / row.mustKeepTotal) * 100);
     console.log(
-      `${row.fixture.padEnd(34)} ${row.reducer.padEnd(18)} tokens ${String(row.beforeTokens).padStart(5)} -> ${String(row.afterTokens).padStart(5)}  (-${row.tokenReductionPct}%)  signal ${row.mustKeepKept}/${row.mustKeepTotal} (${recall}%)`
+      `${row.fixture.padEnd(34)} ${row.reducer.padEnd(18)} tokens ${String(row.beforeTokens).padStart(5)} -> ${String(row.afterTokens).padStart(5)}  (-${row.tokenReductionPct}%)  signal ${row.mustKeepKept}/${row.mustKeepTotal} (${recall}%)  stable ${row.deterministic ? "yes" : "NO"}  idem ${row.idempotent ? "yes" : "NO"}  p95 ${row.latencyP95Ms.toFixed(3)}ms`
     );
     for (const dropped of row.droppedSignalLines) {
       console.log(`    ! dropped signal-looking line: ${dropped}`);
@@ -181,11 +254,23 @@ export function runBench(): BenchReport {
   const droppedSignalLines = rows.reduce((s, r) => s + r.droppedSignalLines.length, 0);
   const signalRecallPct = signalTotal === 0 ? 100 : Math.round((signalKept / signalTotal) * 1000) / 10;
   const fidelityOk = signalKept === signalTotal && droppedSignalLines === 0;
+  const determinismOk = rows.every((row) => row.deterministic);
+  const idempotencyOk = rows.every((row) => row.idempotent);
+  const latencyOk = rows.every((row) => row.latencyOk);
+  const maxLatencyP95Ms = roundMs(Math.max(0, ...rows.map((row) => row.latencyP95Ms)));
+  const integrityOk = fidelityOk && determinismOk && idempotencyOk && latencyOk;
 
-  console.log(`\nTokens:  ${totalBefore} -> ${totalAfter} (-${overallPct}%)`);
-  console.log(`Signal:  ${signalKept}/${signalTotal} must-keep lines preserved (${signalRecallPct}% recall)`);
-  console.log(`Audit:   ${droppedSignalLines} dropped line(s) that look like signal`);
-  console.log(`Verdict: ${fidelityOk ? "fidelity OK — token savings preserve the signal" : "FIDELITY FAILURE — signal lost, see above"}`);
+  console.log(`\nTokens:       ${totalBefore} -> ${totalAfter} (-${overallPct}%)`);
+  console.log(`Signal:       ${signalKept}/${signalTotal} must-keep lines preserved (${signalRecallPct}% recall)`);
+  console.log(`Audit:        ${droppedSignalLines} dropped line(s) that look like signal`);
+  console.log(`Determinism:  ${determinismOk ? "OK" : "FAILURE"}`);
+  console.log(`Idempotency:  ${idempotencyOk ? "OK" : "FAILURE"}`);
+  console.log(
+    `Latency:      ${latencyOk ? "OK" : "FAILURE"} — max fixture p95 ${maxLatencyP95Ms.toFixed(3)}ms (budget ${LATENCY_P95_BUDGET_MS}ms)`
+  );
+  console.log(
+    `Verdict:      ${integrityOk ? "integrity OK — savings preserve signal, stability and latency budget" : "INTEGRITY FAILURE — see failed gate above"}`
+  );
 
   fs.mkdirSync(path.dirname(reportPath), { recursive: true });
   const report: BenchReport = {
@@ -198,6 +283,11 @@ export function runBench(): BenchReport {
     signalRecallPct,
     droppedSignalLines,
     fidelityOk,
+    determinismOk,
+    idempotencyOk,
+    latencyOk,
+    maxLatencyP95Ms,
+    integrityOk,
   };
   fs.writeFileSync(reportPath, JSON.stringify(report, null, 2) + "\n");
   console.log(`\nReport written to ${path.relative(process.cwd(), reportPath)}`);
@@ -207,6 +297,7 @@ export function runBench(): BenchReport {
 // Auto-run when executed directly (node src/run.ts), but not when imported.
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const report = runBench();
-  // A benchmark that silently loses signal is worse than useless — fail loudly.
-  if (!report.fidelityOk) process.exitCode = 1;
+  // A saving that loses signal, changes unpredictably, fails idempotency or consumes excessive
+  // local latency is not an optimization. Release CI uses this as a product-integrity gate.
+  if (!report.integrityOk) process.exitCode = 1;
 }

--- a/packages/core/src/dispatch.test.ts
+++ b/packages/core/src/dispatch.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { pickReducer, reduceAuto, DEFAULT_MIN_LENGTH } from "./dispatch.ts";
+import { pickReducer, reduceAuto, runReducerSafely, DEFAULT_MIN_LENGTH } from "./dispatch.ts";
+import type { Reducer } from "./reducers/types.ts";
 
 const bigGitDiff =
   "diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml\n--- a/pnpm-lock.yaml\n+++ b/pnpm-lock.yaml\n@@ -1,2 +1,3 @@\n foo\n+bar\n" +
@@ -95,6 +96,41 @@ test("reduceAuto: never returns output larger than input (safety net)", () => {
     assert.equal(res.changed, false);
     assert.equal(res.reducer, null);
   }
+});
+
+test("runReducerSafely: reducer exceptions fail open byte-for-byte", () => {
+  const exploding: Reducer = {
+    name: "exploding-test-reducer",
+    reduce() {
+      throw new Error("synthetic reducer failure");
+    },
+  };
+  const input = "signal that must survive\n" + "x".repeat(DEFAULT_MIN_LENGTH);
+
+  const result = runReducerSafely(exploding, input);
+
+  assert.equal(result.output, input);
+  assert.equal(result.changed, false);
+  assert.equal(result.reducer, null);
+  assert.deepEqual(result.reductionError, {
+    reducer: "exploding-test-reducer",
+    message: "synthetic reducer failure",
+  });
+});
+
+test("runReducerSafely: a growing reducer also passes the original through", () => {
+  const growing: Reducer = {
+    name: "growing-test-reducer",
+    reduce(input) {
+      return { output: input + " extra", changed: true };
+    },
+  };
+  const input = "keep me exactly";
+  const result = runReducerSafely(growing, input);
+  assert.equal(result.output, input);
+  assert.equal(result.changed, false);
+  assert.equal(result.reducer, null);
+  assert.equal(result.reductionError, undefined);
 });
 
 test("reduceAuto: idempotent", () => {

--- a/packages/core/src/dispatch.ts
+++ b/packages/core/src/dispatch.ts
@@ -43,9 +43,21 @@ export function pickReducer(text: string): Reducer | null {
   return null;
 }
 
+export interface ReductionError {
+  readonly reducer: string;
+  readonly message: string;
+}
+
 export interface AutoReduceResult extends ReducerResult {
   /** Name of the reducer that ran, or null if none matched / input too short. */
   readonly reducer: string | null;
+  /**
+   * Present only when a matched reducer threw.
+   *
+   * Reduction is an optimization, never a correctness dependency: on failure the original input
+   * passes through byte-for-byte and adapters may record this metadata without reconstructing it.
+   */
+  readonly reductionError?: ReductionError;
 }
 
 /**
@@ -54,6 +66,29 @@ export interface AutoReduceResult extends ReducerResult {
  * `minLength`. Deterministic and idempotent, inheriting those guarantees from the
  * underlying reducers.
  */
+export function runReducerSafely(reducer: Reducer, text: string): AutoReduceResult {
+  try {
+    const result = reducer.reduce(text);
+    // Safety net: never emit output larger than the input. On tiny inputs a collapse
+    // marker can exceed the few lines it replaces; reduction must never backfire on
+    // cost or cache, so fall back to the original in that case.
+    if (!result.changed || result.output.length >= text.length) {
+      return { output: text, changed: false, reducer: null };
+    }
+    return { ...result, reducer: reducer.name };
+  } catch (error) {
+    return {
+      output: text,
+      changed: false,
+      reducer: null,
+      reductionError: {
+        reducer: reducer.name,
+        message: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+}
+
 export function reduceAuto(text: string, minLength: number = DEFAULT_MIN_LENGTH): AutoReduceResult {
   if (text.length < minLength) {
     return { output: text, changed: false, reducer: null };
@@ -62,12 +97,5 @@ export function reduceAuto(text: string, minLength: number = DEFAULT_MIN_LENGTH)
   if (!reducer) {
     return { output: text, changed: false, reducer: null };
   }
-  const result = reducer.reduce(text);
-  // Safety net: never emit output larger than the input. On tiny inputs a collapse
-  // marker can exceed the few lines it replaces; reduction must never backfire on
-  // cost or cache, so fall back to the original in that case.
-  if (!result.changed || result.output.length >= text.length) {
-    return { output: text, changed: false, reducer: null };
-  }
-  return { ...result, reducer: reducer.name };
+  return runReducerSafely(reducer, text);
 }


### PR DESCRIPTION
Hardens HarnessTrim using the useful operational ideas from TokenSaver-like local optimizers without introducing a proxy/daemon.

### Core
- shared reducer execution is now fail-open;
- a reducer exception returns the original payload byte-for-byte;
- failure metadata includes reducer name + error message for downstream diagnostics;
- the existing no-growth safety net is centralized in the same safe runner.

### Tier A release gate
Every fixture now measures and gates:
- signal fidelity / dropped-signal audit;
- deterministic output across repeated runs;
- idempotent second pass;
- reducer p95 latency with a 25 ms per-fixture budget.

The benchmark uses warm-up + 100 measured iterations so scheduler noise does not turn one spike into a regression. Existing CI/release already run Tier A, so no new workflow/proxy is needed.

Docs update the KPI contract accordingly.