### PR TITLE
feat: track fail-open reducer failures across harnesses

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -354,8 +354,11 @@ telemetry and preserve benchmark signal recall.
 
 **Reducer-runtime hardening:** the shared in-process dispatcher is fail-open: a reducer exception
 passes the original payload through byte-for-byte and exposes failure metadata instead of breaking
-the harness. Tier A is also promoted from a reduction/fidelity check to a release gate over four
-properties: 100% signal recall/audit, deterministic output, idempotent second pass, and p95 reducer
+the harness. The telemetry path now preserves that distinction across direct adapters and
+CLI-backed Pi/OMP/Hermes integrations: fail-open exceptions are counted separately from ordinary
+pass-throughs and growth errors, attributed by reducer/harness, while exception messages and tool
+payloads are not persisted. Tier A is also promoted from a reduction/fidelity check to a release
+gate over four properties: 100% signal recall/audit, deterministic output, idempotent second pass, and p95 reducer
 latency ≤ 25 ms on every fixed fixture. This borrows the useful operational discipline of local
 token-optimizer products without introducing a mandatory proxy/daemon or another network hop.
 

--- a/README.md
+++ b/README.md
@@ -353,12 +353,14 @@ pnpm exec harnesstrim bench                    # run the Tier A reducer micro-be
   available narrowing flags, and the exact write-set each installer owns.
 - `doctor`, `install`, and `metrics` accept `--json` for machine-readable output (scripts/CI).
 - `reduce` is the pipe-friendly reducer (RTK-style) shared across harnesses.
-- `metrics` aggregates the telemetry the adapter emits (off by default) into totals with
-  **per-reducer** and **per-harness** splits, a **pass-through rate** (attempted-but-unchanged
-  output — the evidence base for adding reducers) and **reduction-error** counts (attempts that grew
-  the output). Pass-throughs are recorded whenever telemetry is on; opt out with
-  `HARNESSTRIM_TRACK_PASSTHROUGH=0`. Lines carry a schema version and a stable event id; only
-  character counts are recorded, never tool payloads.
+- `metrics` aggregates the telemetry the adapter emits into totals with **per-reducer** and
+  **per-harness** splits, a **pass-through rate** (no reducer matched), **fail-open reducer failure**
+  counts (a reducer threw but the original output was preserved), and **growth-error** counts
+  (an attempted reduction grew the output). Pass-throughs can be opted out with
+  `HARNESSTRIM_TRACK_PASSTHROUGH=0`; reducer failures are still recorded whenever telemetry is
+  enabled because they are operational errors, not ordinary misses. Lines carry a schema version
+  and stable event id. Only counts/status are recorded, never tool payloads or reducer exception
+  messages.
 
 ## Try it
 
@@ -394,7 +396,7 @@ harness. "dry-run mode" here means the adapter logs what it *would* slim without
 | Claude Code | **Via the pipe / MCP** — the `PostToolUse` hook is spec-correct but Claude Code 2.1.37–2.1.212 don't apply `updatedToolOutput`, so `install claude` also adds a `CLAUDE.md` instruction to pipe noisy output through `harnesstrim reduce` (slims in-shell before the model sees it) and registers the MCP `reduce` tool. | keep the CLAUDE.md instruction / MCP registration | **on** — the pipe instruction uses `harnesstrim reduce --metrics .harnesstrim/metrics.jsonl`; the MCP server records too (`--metrics`) |
 | Codex | Default: model pipes through `harnesstrim reduce` or calls MCP `reduce`. Experimental `--hook`: automatically reduces supported Bash results. | `AGENTS.md` / MCP, project `--hook`, or global `--hook --global` for trusted projects | hook telemetry is written per project to `.harnesstrim/metrics.jsonl`; MCP/pipe telemetry is manual |
 | Hermes | **No** — starts in `dryrun` | set `HARNESSTRIM_MODE=active` in Hermes' persistent environment | off; set `HARNESSTRIM_TELEMETRY=1`, then run `harnesstrim metrics` |
-| Pi | **No** — starts in `dryrun` | set `HARNESSTRIM_MODE=active` **persistently** in Pi's environment | none yet (the extension only reduces) |
+| Pi | **No** — starts in `dryrun` | set `HARNESSTRIM_MODE=active` **persistently** in Pi's environment | set `--metrics <path>` at install or `HARNESSTRIM_METRICS=<path>`; receipts include reductions, pass-throughs and fail-open failures |
 
 Guidance: for the dry-run adapters (Hermes, Pi) keep the default while you confirm it slims the right
 things (watch stderr for `[harnesstrim] dryrun ...` lines), then flip to `active` persistently.
@@ -403,7 +405,7 @@ Telemetry is **off by default everywhere**; enable it only where you want a metr
 Telemetry lines are JSONL with a schema version and a stable event id, e.g.:
 
 ```jsonl
-{"schemaVersion":1,"eventId":"…","ts":"2026-08-01T…","harness":"opencode","tool":"bash","reducer":"test-output-slim","beforeChars":1410,"afterChars":124,"beforeTokens":null,"afterTokens":null}
+{"schemaVersion":1,"eventId":"…","ts":"2026-09-02T…","harness":"opencode","tool":"bash","reducer":"test-output-slim","beforeChars":1410,"afterChars":124,"changed":true,"reductionFailed":false,"beforeTokens":null,"afterTokens":null}
 ```
 
 `beforeTokens`/`afterTokens` are `null` unless the emitting path has real counts (no tokenizer runs in

--- a/packages/adapter-claude/src/hook.ts
+++ b/packages/adapter-claude/src/hook.ts
@@ -18,6 +18,8 @@ export interface ClaudeReduction {
   attempt: {
     tool: string;
     beforeChars: number;
+    reducer: string | null;
+    reductionFailed: boolean;
   } | null;
 }
 
@@ -41,7 +43,12 @@ export function reduceClaudePayload(rawJson: string, minLength?: number): Claude
       event: null,
       attempt:
         extracted.output.length >= (minLength ?? DEFAULT_MIN_LENGTH)
-          ? { tool: extracted.toolName, beforeChars: extracted.output.length }
+          ? {
+              tool: extracted.toolName,
+              beforeChars: extracted.output.length,
+              reducer: result.reductionError?.reducer ?? null,
+              reductionFailed: result.reductionError !== undefined,
+            }
           : null,
     };
   }

--- a/packages/adapter-codex/src/hook.ts
+++ b/packages/adapter-codex/src/hook.ts
@@ -17,6 +17,8 @@ export interface CodexReduction {
   attempt: {
     tool: string;
     beforeChars: number;
+    reducer: string | null;
+    reductionFailed: boolean;
   } | null;
 }
 
@@ -37,7 +39,12 @@ export function reduceCodexPayload(rawJson: string, minLength?: number): CodexRe
       event: null,
       attempt:
         extracted.output.length >= (minLength ?? DEFAULT_MIN_LENGTH)
-          ? { tool: extracted.toolName, beforeChars: extracted.output.length }
+          ? {
+              tool: extracted.toolName,
+              beforeChars: extracted.output.length,
+              reducer: result.reductionError?.reducer ?? null,
+              reductionFailed: result.reductionError !== undefined,
+            }
           : null,
     };
   }

--- a/packages/adapter-hermes/plugin/__init__.py
+++ b/packages/adapter-hermes/plugin/__init__.py
@@ -109,10 +109,11 @@ def _find_harnesstrim_cli() -> str | None:
     return None
 
 
-def _call_reducer(text: str, min_length: int) -> tuple[str, str | None]:
-    """Shell out to ``harnesstrim reduce`` and return (slimmed_text, reducer_name).
+def _call_reducer(text: str, min_length: int) -> tuple[str, str | None, bool]:
+    """Shell out to ``harnesstrim reduce`` and return
+    (slimmed_text, reducer_name, reduction_failed).
 
-    Falls back to (original_text, None) if the CLI cannot be found or the pipe fails.
+    Falls back to (original_text, None, False) if the CLI cannot be found or the pipe fails.
     The reducer name is parsed from the ``--stats`` stderr line (e.g. ``test-output-slim``),
     used only for telemetry when enabled.
     """
@@ -125,10 +126,10 @@ def _call_reducer(text: str, min_length: int) -> tuple[str, str | None]:
             "or build from source: git clone https://github.com/harnesstrim/harnesstrim",
             stacklevel=2,
         )
-        return (text, None)
+        return (text, None, False)
 
     if len(text) < min_length:
-        return (text, None)
+        return (text, None, False)
 
     try:
         result = subprocess.run(
@@ -147,11 +148,12 @@ def _call_reducer(text: str, min_length: int) -> tuple[str, str | None]:
                     rest = line[len("[harnesstrim reduce] "):]
                     if ":" in rest and "no reduction" not in rest:
                         reducer = rest.split(":")[0].strip()
-            return (result.stdout.rstrip("\n"), reducer)
+            reduction_failed = "reducer failed; original output preserved" in result.stderr
+            return (result.stdout.rstrip("\n"), reducer, reduction_failed)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         pass
 
-    return (text, None)
+    return (text, None, False)
 
 
 def _text_targets(payload):
@@ -213,8 +215,17 @@ def on_tool_result(tool_name, args, result, **kwargs):
         if "[harnesstrim:" in text or "[hermes-trim" in text:
             continue
 
-        after, reducer = _call_reducer(text, cfg["minLength"])
+        after, reducer, reduction_failed = _call_reducer(text, cfg["minLength"])
         if after == text:
+            if reduction_failed and cfg["telemetry"]:
+                _write_metric(
+                    tool_name,
+                    reducer,
+                    before_len,
+                    before_len,
+                    changed=False,
+                    reduction_failed=True,
+                )
             continue
 
         changed = True
@@ -238,7 +249,14 @@ def on_tool_result(tool_name, args, result, **kwargs):
     return json.dumps(payload, ensure_ascii=False) if not isinstance(payload, str) else payload
 
 
-def _write_metric(tool: str, reducer: str | None, before: int, after: int) -> None:
+def _write_metric(
+    tool: str,
+    reducer: str | None,
+    before: int,
+    after: int,
+    changed: bool = True,
+    reduction_failed: bool = False,
+) -> None:
     """Append one TrimEvent JSONL line to METRICS_PATH (read by `harnesstrim metrics`).
 
     Only called in active mode when telemetry is explicitly enabled. Creates the parent
@@ -256,7 +274,8 @@ def _write_metric(tool: str, reducer: str | None, before: int, after: int) -> No
         "reducer": reducer,
         "beforeChars": before,
         "afterChars": after,
-        "changed": True,
+        "changed": changed,
+        "reductionFailed": reduction_failed,
         "beforeTokens": None,
         "afterTokens": None,
     }

--- a/packages/adapter-hermes/plugin/__init__.py
+++ b/packages/adapter-hermes/plugin/__init__.py
@@ -149,7 +149,7 @@ def _call_reducer(text: str, min_length: int) -> tuple[str, str | None, bool]:
                     if ":" in rest and "no reduction" not in rest:
                         reducer = rest.split(":")[0].strip()
             reduction_failed = "reducer failed; original output preserved" in result.stderr
-            return (result.stdout.rstrip("\n"), reducer, reduction_failed)
+            return (result.stdout, reducer, reduction_failed)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         pass
 

--- a/packages/adapter-hermes/test/plugin-payload.test.py
+++ b/packages/adapter-hermes/test/plugin-payload.test.py
@@ -27,7 +27,7 @@ class PluginPayloadTests(unittest.TestCase):
         })
         self.original_reducer = plugin._call_reducer
         self.original_metric = plugin._write_metric
-        plugin._call_reducer = lambda text, _min: (f"[trimmed]{text[:8]}", "fixture")
+        plugin._call_reducer = lambda text, _min: (f"[trimmed]{text[:8]}", "fixture", False)
         plugin._write_metric = lambda *_args: None
 
     def tearDown(self):
@@ -65,6 +65,25 @@ class PluginPayloadTests(unittest.TestCase):
         )
         self.assertTrue(result["results"][0]["content"].startswith("[trimmed]"))
         self.assertTrue(result["results"][1]["content"].startswith("[trimmed]"))
+
+    def test_fail_open_reducer_error_records_failure_without_mutating_output(self):
+        os.environ["HARNESSTRIM_TELEMETRY"] = "true"
+        calls = []
+        plugin._call_reducer = lambda text, _min: (text, "fixture", True)
+        plugin._write_metric = lambda *args, **kwargs: calls.append((args, kwargs))
+
+        payload = {"output": "x" * 200}
+        result = plugin.on_tool_result("terminal", {}, json.dumps(payload))
+
+        self.assertIsNone(result)
+        self.assertEqual(len(calls), 1)
+        args, kwargs = calls[0]
+        self.assertEqual(args[0], "terminal")
+        self.assertEqual(args[1], "fixture")
+        self.assertEqual(args[2], 200)
+        self.assertEqual(args[3], 200)
+        self.assertEqual(kwargs["changed"], False)
+        self.assertEqual(kwargs["reduction_failed"], True)
 
 
 if __name__ == "__main__":

--- a/packages/adapter-omp/hook/harnesstrim.ts
+++ b/packages/adapter-omp/hook/harnesstrim.ts
@@ -69,7 +69,7 @@ function reduce(
     });
     const stdout = typeof r.stdout === "string" ? r.stdout : "";
     const stderr = typeof r.stderr === "string" ? r.stderr : "";
-    const output = stdout.replace(/\n$/, "");
+    const output = stdout;
     if (r.status === 0 && output && output.length > 0) {
       return {
         output,

--- a/packages/adapter-omp/hook/harnesstrim.ts
+++ b/packages/adapter-omp/hook/harnesstrim.ts
@@ -58,7 +58,9 @@ interface TextChunk {
   text?: unknown;
 }
 
-function reduce(text: string): { output: string | null; reducer: string | null } {
+function reduce(
+  text: string,
+): { output: string | null; reducer: string | null; reductionFailed: boolean } {
   try {
     const r = spawnSync("harnesstrim", ["reduce", "--min-length", String(MIN_LENGTH), "--stats"], {
       input: text,
@@ -69,12 +71,16 @@ function reduce(text: string): { output: string | null; reducer: string | null }
     const stderr = typeof r.stderr === "string" ? r.stderr : "";
     const output = stdout.replace(/\n$/, "");
     if (r.status === 0 && output && output.length > 0) {
-      return { output, reducer: parseReducer(stderr) };
+      return {
+        output,
+        reducer: parseReducer(stderr),
+        reductionFailed: stderr.includes("reducer failed; original output preserved"),
+      };
     }
   } catch {
     /* harnesstrim not on PATH or failed — pass through */
   }
-  return { output: null, reducer: null };
+  return { output: null, reducer: null, reductionFailed: false };
 }
 
 function parseReducer(stderr: string): string | null {
@@ -98,6 +104,7 @@ function writeMetric(partial: {
   before: number;
   after: number;
   changed: boolean;
+  reductionFailed?: boolean;
 }): void {
   if (!METRICS_PATH) return;
   try {
@@ -114,6 +121,7 @@ function writeMetric(partial: {
       beforeChars: partial.before,
       afterChars: partial.after,
       changed: partial.changed,
+      reductionFailed: partial.reductionFailed ?? false,
       beforeTokens: null,
       afterTokens: null,
     };
@@ -135,10 +143,17 @@ export default function harnessTrim(pi: { on(event: string, handler: (event: unk
       const text = chunk.text;
       if (text.length < MIN_LENGTH || text.includes(MARKER)) return chunk;
 
-      const { output: reduced, reducer } = reduce(text);
+      const { output: reduced, reducer, reductionFailed } = reduce(text);
       if (!reduced || reduced.length >= text.length) {
         if (METRICS_PATH) {
-          writeMetric({ tool: eventTool(ev), reducer: null, before: text.length, after: text.length, changed: false });
+          writeMetric({
+            tool: eventTool(ev),
+            reducer: reductionFailed ? reducer : null,
+            before: text.length,
+            after: text.length,
+            changed: false,
+            reductionFailed,
+          });
         }
         return chunk;
       }

--- a/packages/adapter-opencode/src/plugin.ts
+++ b/packages/adapter-opencode/src/plugin.ts
@@ -57,6 +57,19 @@ export const HarnessTrim: Plugin = async (_input, options) => {
           })
         );
         log(`${config.mode} ${input.tool} via ${result.reducer}: ${before} -> ${after} chars`);
+      } else if (result.reductionError !== undefined) {
+        sink(
+          makeTrimEvent({
+            harness: HARNESS,
+            tool: input.tool,
+            reducer: result.reductionError.reducer,
+            beforeChars: before,
+            afterChars: before,
+            changed: false,
+            reductionFailed: true,
+          })
+        );
+        log(`fail-open ${input.tool} via ${result.reductionError.reducer}: original output preserved`);
       } else if (config.trackPassThrough && before >= config.minLength) {
         // Attempted but nothing changed: record the pass-through so `metrics` can
         // report the share of unreduced output (the evidence base for new reducers).

--- a/packages/adapter-pi/extension/index.ts
+++ b/packages/adapter-pi/extension/index.ts
@@ -111,7 +111,7 @@ function reduceViaCli(
       timeout: 30000,
     });
     if (r.status === 0 && typeof r.stdout === "string" && r.stdout.length > 0) {
-      const output = r.stdout.replace(/\n$/, "");
+      const output = r.stdout;
       const stderr = typeof r.stderr === "string" ? r.stderr : "";
       const reducer = parseReducer(stderr);
       return {

--- a/packages/adapter-pi/extension/index.ts
+++ b/packages/adapter-pi/extension/index.ts
@@ -101,7 +101,9 @@ function parseReducer(stderr: string): string | null {
   return null;
 }
 
-function reduceViaCli(text: string): { output: string | null; reducer: string | null } {
+function reduceViaCli(
+  text: string,
+): { output: string | null; reducer: string | null; reductionFailed: boolean } {
   try {
     const r = spawnSync("harnesstrim", ["reduce", "--min-length", String(MIN_LENGTH), "--stats"], {
       input: text,
@@ -110,13 +112,18 @@ function reduceViaCli(text: string): { output: string | null; reducer: string | 
     });
     if (r.status === 0 && typeof r.stdout === "string" && r.stdout.length > 0) {
       const output = r.stdout.replace(/\n$/, "");
-      const reducer = typeof r.stderr === "string" ? parseReducer(r.stderr) : null;
-      return { output, reducer };
+      const stderr = typeof r.stderr === "string" ? r.stderr : "";
+      const reducer = parseReducer(stderr);
+      return {
+        output,
+        reducer,
+        reductionFailed: stderr.includes("reducer failed; original output preserved"),
+      };
     }
   } catch {
     /* harnesstrim not on PATH or failed — pass through */
   }
-  return { output: null, reducer: null };
+  return { output: null, reducer: null, reductionFailed: false };
 }
 
 /** Append a TrimEvent JSONL receipt (self-contained: no workspace imports allowed). */
@@ -126,6 +133,7 @@ function writeMetric(partial: {
   before: number;
   after: number;
   changed: boolean;
+  reductionFailed?: boolean;
 }): void {
   if (!METRICS_PATH) return;
   try {
@@ -142,6 +150,7 @@ function writeMetric(partial: {
       beforeChars: partial.before,
       afterChars: partial.after,
       changed: partial.changed,
+      reductionFailed: partial.reductionFailed ?? false,
       beforeTokens: null,
       afterTokens: null,
     };
@@ -163,11 +172,18 @@ export default function harnesstrim(pi: ExtensionAPI): void {
       const text = chunk.text;
       if (shouldSkip(text, MIN_LENGTH)) return chunk;
 
-      const { output: reduced, reducer } = reduceViaCli(text);
+      const { output: reduced, reducer, reductionFailed } = reduceViaCli(text);
       if (!reduced || reduced.length >= text.length) {
-        // Attempted reduction, nothing changed — a recorded pass-through.
+        // A reducer exception is a distinct fail-open event; a no-match is a pass-through.
         if (METRICS_PATH) {
-          writeMetric({ tool: eventTool(event), reducer: null, before: text.length, after: text.length, changed: false });
+          writeMetric({
+            tool: eventTool(event),
+            reducer: reductionFailed ? reducer : null,
+            before: text.length,
+            after: text.length,
+            changed: false,
+            reductionFailed,
+          });
         }
         return chunk;
       }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -309,7 +309,7 @@ async function main(argv: string[]): Promise<number> {
                 })
               ) + "\n"
             );
-          } else if (attempt && trackPassThrough()) {
+          } else if (attempt && (attempt.reductionFailed || trackPassThrough())) {
             fs.appendFileSync(
               p,
               JSON.stringify(
@@ -317,10 +317,11 @@ async function main(argv: string[]): Promise<number> {
                   ts: new Date().toISOString(),
                   harness: which,
                   tool: attempt.tool,
-                  reducer: null,
+                  reducer: attempt.reducer,
                   beforeChars: attempt.beforeChars,
                   afterChars: attempt.beforeChars,
                   changed: false,
+                  reductionFailed: attempt.reductionFailed,
                 })
               ) + "\n"
             );
@@ -405,7 +406,10 @@ async function main(argv: string[]): Promise<number> {
                 })
               ) + "\n"
             );
-          } else if (trackPassThrough() && input.length >= (minLength ?? DEFAULT_MIN_LENGTH)) {
+          } else if (
+            result.reductionError !== undefined ||
+            (trackPassThrough() && input.length >= (minLength ?? DEFAULT_MIN_LENGTH))
+          ) {
             fs.appendFileSync(
               p,
               JSON.stringify(
@@ -413,10 +417,11 @@ async function main(argv: string[]): Promise<number> {
                   ts: new Date().toISOString(),
                   harness: "pipe",
                   tool: "reduce",
-                  reducer: null,
+                  reducer: result.reductionError?.reducer ?? null,
                   beforeChars: input.length,
                   afterChars: input.length,
                   changed: false,
+                  reductionFailed: result.reductionError !== undefined,
                   beforeTokens: countTokens(input),
                   afterTokens: countTokens(input),
                 })
@@ -430,7 +435,9 @@ async function main(argv: string[]): Promise<number> {
       if (values.stats) {
         const note = result.changed
           ? `${result.reducer}: ${result.beforeChars} -> ${result.afterChars} chars`
-          : "no reduction (no reducer matched or below min-length)";
+          : result.reductionError !== undefined
+            ? `${result.reductionError.reducer}: reducer failed; original output preserved`
+            : "no reduction (no reducer matched or below min-length)";
         console.error(`[harnesstrim reduce] ${note}`);
       }
       return 0;

--- a/packages/cli/src/metrics.test.ts
+++ b/packages/cli/src/metrics.test.ts
@@ -49,12 +49,44 @@ test("loadMetrics reports pass-through and per-harness splits", () => {
   assert.equal(result.summary.reduced, 2);
   assert.equal(result.summary.passThrough, 1);
   assert.equal(result.summary.passThroughRate, 33.3);
+  assert.equal(result.summary.reducerFailures, 0);
   assert.equal(result.summary.reductionErrors, 0);
-assert.deepEqual(
+  assert.deepEqual(
     result.summary.byHarness.map((h) => h.harness),
     ["opencode", "claude"] // sorted by saved chars desc (opencode saved 700, claude 300)
   );
   assert.equal(result.summary.byHarness[0].savedChars, 700);
+});
+
+test("loadMetrics reports fail-open reducer failures separately from pass-throughs", () => {
+  const p = tmpFile(
+    line({
+      harness: "opencode",
+      tool: "bash",
+      reducer: "test-output-slim",
+      beforeChars: 600,
+      afterChars: 600,
+      changed: false,
+      reductionFailed: true,
+    }) +
+      "\n" +
+      line({
+        harness: "opencode",
+        tool: "read",
+        reducer: null,
+        beforeChars: 500,
+        afterChars: 500,
+        changed: false,
+      }) +
+      "\n",
+  );
+  const result = loadMetrics(p);
+  assert.equal(result.summary.reducerFailures, 1);
+  assert.equal(result.summary.passThrough, 1);
+  assert.equal(result.summary.reductionErrors, 0);
+  assert.equal(result.summary.byReducer[0]?.reducer, "test-output-slim");
+  assert.equal(result.summary.byReducer[0]?.failures, 1);
+  assert.equal(result.summary.byHarness[0]?.failures, 1);
 });
 
 test("loadMetrics reports reduction errors when output grew", () => {

--- a/packages/cli/src/render.ts
+++ b/packages/cli/src/render.ts
@@ -322,10 +322,15 @@ export function renderMetrics(result: MetricsResult): string {
   const lines = [
     `harnesstrim metrics — ${result.path}`,
     "",
-    `Attempts:     ${s.events} (${s.reduced} reduced, ${s.passThrough} pass-through, ${s.reductionErrors} error)`,
+    `Attempts:     ${s.events} (${s.reduced} reduced, ${s.passThrough} pass-through, ${s.reducerFailures} reducer failure, ${s.reductionErrors} growth error)`,
     `Pass-through: ${s.passThroughRate}% of attempts unchanged`,
     `Chars:        ${s.beforeChars} -> ${s.afterChars}  (saved ${s.savedChars}, -${s.reductionPct}%)`,
   ];
+  if (s.reducerFailures > 0) {
+    lines.push(
+      `Reducer failures: ${s.reducerFailures} fail-open attempt(s) preserved the original output — investigate`,
+    );
+  }
   if (s.reductionErrors > 0) {
     lines.push(`Reduction errors: ${s.reductionErrors} attempt(s) GREW the output (+${s.grewChars} chars) — investigate`);
   }
@@ -333,7 +338,9 @@ export function renderMetrics(result: MetricsResult): string {
   lines.push("By reducer:");
   for (const b of s.byReducer) {
     const p = b.beforeChars === 0 ? 0 : Math.round((b.savedChars / b.beforeChars) * 1000) / 10;
-    lines.push(`  ${b.reducer.padEnd(20)} ${b.count}x  saved ${b.savedChars} chars (-${p}%)`);
+    lines.push(
+      `  ${b.reducer.padEnd(20)} ${b.count}x  saved ${b.savedChars} chars (-${p}%)${b.failures > 0 ? `  failures ${b.failures}` : ""}`,
+    );
   }
   if (s.byHarness.length > 0) {
     lines.push("");
@@ -341,7 +348,9 @@ export function renderMetrics(result: MetricsResult): string {
     for (const h of s.byHarness) {
       const p = h.beforeChars === 0 ? 0 : Math.round((h.savedChars / h.beforeChars) * 1000) / 10;
       const sign = p < 0 ? "" : "-";
-      lines.push(`  ${h.harness.padEnd(12)} ${h.count}x  saved ${h.savedChars} chars (${sign}${Math.abs(p)}%)`);
+      lines.push(
+        `  ${h.harness.padEnd(12)} ${h.count}x  saved ${h.savedChars} chars (${sign}${Math.abs(p)}%)${h.failures > 0 ? `  failures ${h.failures}` : ""}`,
+      );
     }
   }
   return lines.join("\n");

--- a/packages/core/src/metrics/trim-event.test.ts
+++ b/packages/core/src/metrics/trim-event.test.ts
@@ -36,6 +36,7 @@ test("summarize handles empty input", () => {
   assert.deepEqual(s.byReducer, []);
   assert.deepEqual(s.byHarness, []);
   assert.equal(s.passThroughRate, 0);
+  assert.equal(s.reducerFailures, 0);
 });
 
 test("summarize counts pass-throughs, errors, and per-harness totals", () => {
@@ -57,6 +58,39 @@ test("summarize counts pass-throughs, errors, and per-harness totals", () => {
   assert.equal(s.byHarness[0].savedChars, 700);
   assert.equal(s.byHarness[2].harness, "pipe");
   assert.equal(s.byHarness[2].reductionPct, -50);
+});
+
+test("summarize separates fail-open reducer exceptions from ordinary pass-throughs", () => {
+  const s = summarize([
+    makeTrimEvent({
+      harness: "opencode",
+      tool: "bash",
+      reducer: "test-output-slim",
+      beforeChars: 1000,
+      afterChars: 1000,
+      changed: false,
+      reductionFailed: true,
+    }),
+    makeTrimEvent({
+      harness: "opencode",
+      tool: "read",
+      reducer: null,
+      beforeChars: 800,
+      afterChars: 800,
+      changed: false,
+    }),
+  ]);
+
+  assert.equal(s.events, 2);
+  assert.equal(s.reducerFailures, 1);
+  assert.equal(s.passThrough, 1);
+  assert.equal(s.passThroughRate, 50);
+  assert.equal(s.reduced, 0);
+  assert.equal(s.reductionErrors, 0);
+  assert.equal(s.byReducer[0]?.reducer, "test-output-slim");
+  assert.equal(s.byReducer[0]?.failures, 1);
+  assert.equal(s.byHarness[0]?.harness, "opencode");
+  assert.equal(s.byHarness[0]?.failures, 1);
 });
 
 test("parseTrimEvents skips blank and malformed lines", () => {
@@ -87,13 +121,31 @@ test("makeTrimEvent stamps the schema envelope (version 1, stable eventId, null 
   assert.equal(e.beforeTokens, null);
   assert.equal(e.afterTokens, null);
   assert.equal(e.changed, true);
+  assert.equal(e.reductionFailed, false);
   assert.ok(Number.isFinite(Date.parse(e.ts)));
 });
 
 test("makeTrimEvent records a pass-through with changed: false", () => {
   const e = makeTrimEvent({ harness: "opencode", tool: "bash", reducer: null, beforeChars: 50, afterChars: 50, changed: false });
   assert.equal(e.changed, false);
+  assert.equal(e.reductionFailed, false);
   assert.equal(e.reducer, null);
+});
+
+test("makeTrimEvent records fail-open status without an exception message", () => {
+  const e = makeTrimEvent({
+    harness: "opencode",
+    tool: "bash",
+    reducer: "test-output-slim",
+    beforeChars: 50,
+    afterChars: 50,
+    changed: false,
+    reductionFailed: true,
+  });
+  assert.equal(e.changed, false);
+  assert.equal(e.reductionFailed, true);
+  assert.equal(e.reducer, "test-output-slim");
+  assert.equal("message" in e, false);
 });
 
 test("makeTrimEvent carries token counts when the emitting path provides them", () => {
@@ -126,4 +178,5 @@ test("parseTrimEvents normalizes legacy lines (no schema) to schemaVersion 0 and
   assert.equal(parsed[0].beforeTokens, null);
   assert.equal(parsed[0].afterChars, 400);
   assert.equal(parsed[0].changed, true);
+  assert.equal(parsed[0].reductionFailed, false);
 });

--- a/packages/core/src/metrics/trim-event.ts
+++ b/packages/core/src/metrics/trim-event.ts
@@ -23,6 +23,10 @@ import { randomUUID } from "node:crypto";
  * pass-through (an attempted reduction that changed nothing) so `metrics` can report a
  * pass-through rate — the denominator for deciding which noisy-output classes still need
  * a reducer. Legacy lines without the field normalize to `changed: true`.
+ *
+ * Runtime hardening (2026-09-02): additive `reductionFailed` field. A reducer exception
+ * is fail-open, so the original payload still reaches the harness; telemetry records only
+ * that the reducer failed and its reducer name. Exception messages/payloads are never persisted.
  */
 export const TRIM_EVENT_SCHEMA_VERSION = 1;
 
@@ -43,6 +47,8 @@ export interface TrimEvent {
   afterChars: number;
   /** True when the attempt actually changed the output; false marks a recorded pass-through. */
   changed: boolean;
+  /** True only when a matched reducer threw and the original payload passed through unchanged. */
+  reductionFailed: boolean;
   /** Token count before reduction, only when the emitting path has one; else null. */
   beforeTokens: number | null;
   /** Token count after reduction, only when the emitting path has one; else null. */
@@ -53,14 +59,18 @@ export interface TrimEvent {
  * Build a fully-formed, schema-versioned TrimEvent. Producers should use this instead of
  * hand-rolling the envelope so `schemaVersion`/`eventId` cannot drift between adapters.
  * Token counts default to null (measured only where the emitting path has a tokenizer);
- * `changed` defaults true (reduced) and is set false for recorded pass-throughs.
+ * `changed` defaults true (reduced), while `reductionFailed` defaults false.
  */
 export function makeTrimEvent(
-  partial: Omit<TrimEvent, "schemaVersion" | "eventId" | "ts" | "beforeTokens" | "afterTokens" | "changed"> & {
+  partial: Omit<
+    TrimEvent,
+    "schemaVersion" | "eventId" | "ts" | "beforeTokens" | "afterTokens" | "changed" | "reductionFailed"
+  > & {
     ts?: string;
     beforeTokens?: number | null;
     afterTokens?: number | null;
     changed?: boolean;
+    reductionFailed?: boolean;
   }
 ): TrimEvent {
   return {
@@ -73,6 +83,7 @@ export function makeTrimEvent(
     beforeChars: partial.beforeChars,
     afterChars: partial.afterChars,
     changed: partial.changed ?? true,
+    reductionFailed: partial.reductionFailed ?? false,
     beforeTokens: partial.beforeTokens ?? null,
     afterTokens: partial.afterTokens ?? null,
   };
@@ -81,6 +92,8 @@ export function makeTrimEvent(
 export interface ReducerBreakdown {
   reducer: string;
   count: number;
+  /** Fail-open exceptions attributed to this reducer. */
+  failures: number;
   beforeChars: number;
   afterChars: number;
   savedChars: number;
@@ -89,6 +102,8 @@ export interface ReducerBreakdown {
 export interface HarnessBreakdown {
   harness: string;
   count: number;
+  /** Fail-open reducer exceptions observed on this harness. */
+  failures: number;
   beforeChars: number;
   afterChars: number;
   savedChars: number;
@@ -113,6 +128,8 @@ export interface TrimSummary {
   passThrough: number;
   /** Percent of recorded attempts that were pass-throughs, one decimal place. */
   passThroughRate: number;
+  /** Fail-open reducer exceptions; original payloads were preserved. */
+  reducerFailures: number;
   /** Attempts recorded as changed that GROW the output — reducer bugs worth fixing. */
   reductionErrors: number;
   /** Total growth in chars across reduction errors. */
@@ -135,6 +152,7 @@ export function summarize(events: TrimEvent[]): TrimSummary {
   let afterChars = 0;
   let reduced = 0;
   let passThrough = 0;
+  let reducerFailures = 0;
   let reductionErrors = 0;
   let grewChars = 0;
   const byReducerMap = new Map<string, ReducerBreakdown>();
@@ -143,7 +161,9 @@ export function summarize(events: TrimEvent[]): TrimSummary {
   for (const e of events) {
     beforeChars += e.beforeChars;
     afterChars += e.afterChars;
-    if (e.changed === false) {
+    if (e.reductionFailed) {
+      reducerFailures++;
+    } else if (e.changed === false) {
       passThrough++;
     } else if (e.afterChars > e.beforeChars) {
       reductionErrors++;
@@ -155,8 +175,17 @@ export function summarize(events: TrimEvent[]): TrimSummary {
     const harness = e.harness ?? "unknown";
     const h =
       byHarnessMap.get(harness) ??
-      { harness, count: 0, beforeChars: 0, afterChars: 0, savedChars: 0, reductionPct: 0 };
+      {
+        harness,
+        count: 0,
+        failures: 0,
+        beforeChars: 0,
+        afterChars: 0,
+        savedChars: 0,
+        reductionPct: 0,
+      };
     h.count += 1;
+    if (e.reductionFailed) h.failures += 1;
     h.beforeChars += e.beforeChars;
     h.afterChars += e.afterChars;
     h.savedChars += e.beforeChars - e.afterChars;
@@ -165,8 +194,16 @@ export function summarize(events: TrimEvent[]): TrimSummary {
     if (e.reducer === null) continue;
     const b =
       byReducerMap.get(e.reducer) ??
-      { reducer: e.reducer, count: 0, beforeChars: 0, afterChars: 0, savedChars: 0 };
+      {
+        reducer: e.reducer,
+        count: 0,
+        failures: 0,
+        beforeChars: 0,
+        afterChars: 0,
+        savedChars: 0,
+      };
     b.count += 1;
+    if (e.reductionFailed) b.failures += 1;
     b.beforeChars += e.beforeChars;
     b.afterChars += e.afterChars;
     b.savedChars += e.beforeChars - e.afterChars;
@@ -189,6 +226,7 @@ export function summarize(events: TrimEvent[]): TrimSummary {
     reduced,
     passThrough,
     passThroughRate: events.length === 0 ? 0 : Math.round((passThrough / events.length) * 1000) / 10,
+    reducerFailures,
     reductionErrors,
     grewChars,
   };
@@ -240,6 +278,7 @@ function normalize(v: TrimEvent): TrimEvent {
     beforeChars: v.beforeChars,
     afterChars: v.afterChars,
     changed: typeof v.changed === "boolean" ? v.changed : true,
+    reductionFailed: typeof v.reductionFailed === "boolean" ? v.reductionFailed : false,
     beforeTokens: typeof v.beforeTokens === "number" ? v.beforeTokens : null,
     afterTokens: typeof v.afterTokens === "number" ? v.afterTokens : null,
   };

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -60,6 +60,20 @@ export function runReduceTool(
         afterTokens: countTokens ? countTokens(result.output) : undefined,
       })
     );
+  } else if (result.reductionError !== undefined) {
+    sink(
+      makeTrimEvent({
+        harness: "mcp",
+        tool: "reduce",
+        reducer: result.reductionError.reducer,
+        beforeChars: text.length,
+        afterChars: text.length,
+        changed: false,
+        reductionFailed: true,
+        beforeTokens: countTokens ? countTokens(text) : undefined,
+        afterTokens: countTokens ? countTokens(text) : undefined,
+      })
+    );
   } else if (trackPassThrough && text.length >= threshold) {
     sink(
       makeTrimEvent({


### PR DESCRIPTION
Extends the fail-open runtime hardening with cross-harness telemetry.

What changes:
- TrimEvent adds additive `reductionFailed` (legacy lines normalize to false).
- metrics separates normal pass-throughs, fail-open reducer exceptions, and growth errors.
- failures are attributed per reducer and per harness.
- exception messages and tool payloads are never persisted.
- OpenCode, MCP, pipe, Claude/Codex hooks, Pi, OMP and Hermes propagate the failure state.
- reducer failures are recorded whenever telemetry is enabled even when ordinary pass-through tracking is disabled.
- Pi/OMP/Hermes no longer strip a trailing newline from CLI reducer output, so fail-open/pass-through remains byte-for-byte.

README/PLAN document the updated contract.