### PR TITLE
release: HarnessTrim 0.2.0

### DIFF
--- a/.github/workflows/release-bridge.yml
+++ b/.github/workflows/release-bridge.yml
@@ -1,0 +1,45 @@
+name: release bridge
+
+on:
+  push:
+    branches:
+      - 'release/v*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-bridge-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: create validated release tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate release branch
+        id: release
+        shell: bash
+        run: |
+          version="$(node -p "require('./packages/cli/package.json').version")"
+          expected="release/v$version"
+          if [ "$GITHUB_REF_NAME" != "$expected" ]; then
+            echo "release branch $GITHUB_REF_NAME does not match package version $version" >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/v$version" >/dev/null 2>&1; then
+            echo "tag v$version already exists" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Create release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/tags/v$VERSION" \
+            -f sha="$GITHUB_SHA"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harnesstrim",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "HarnessTrim CLI: doctor (diagnose token waste), install adapters, run benchmarks.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Prepares HarnessTrim 0.2.0 for empirical Token Harness benchmarking.

- bumps the published CLI to 0.2.0;
- adds a validated `release/vX.Y.Z` branch bridge that creates the corresponding tag;
- keeps the existing tag-driven release workflow as the publisher, so npm publish and GitHub release remain gated by the normal quality job.

This release includes the post-0.1.0 OMP adapter/onboarding work, exact token accounting improvements, capability digests, installer hardening, and fail-open reducer telemetry needed by current Token Harness.