### PR TITLE
fix: dispatch release workflow without a checkout

### DIFF
--- a/.github/workflows/release-command.yml
+++ b/.github/workflows/release-command.yml
@@ -37,4 +37,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.release.outputs.tag }}
-        run: gh workflow run release.yml --ref "$TAG"
+        run: gh api --method POST "repos/$GITHUB_REPOSITORY/actions/workflows/release.yml/dispatches" -f ref="$TAG"


### PR DESCRIPTION
The owner-only release command ran correctly through tag validation, but `gh workflow run` implicitly required a local git repository. The command workflow intentionally has no checkout. Dispatch directly through the GitHub Actions API instead, passing the already-validated tag as the ref.