### PR TITLE
fix(release): repair npm CLI bin in 0.2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,22 @@ jobs:
           cache: pnpm
           registry-url: "https://registry.npmjs.org"
       - run: pnpm install --frozen-lockfile
+      - name: Refuse publish-time bin stripping
+        working-directory: packages/cli
+        run: |
+          npm publish --dry-run --json >/tmp/harnesstrim-publish.json 2>/tmp/harnesstrim-publish.stderr
+          cat /tmp/harnesstrim-publish.stderr
+          if grep -Eq 'bin\\[harnesstrim\\].*(invalid|removed)|script name .* was invalid and removed' /tmp/harnesstrim-publish.stderr; then
+            echo "npm publish would remove the harnesstrim executable" >&2
+            exit 1
+          fi
+          expected="$(node -p "require('./package.json').version")"
+          actual="$(node dist/cli.mjs --version)"
+          test "$actual" = "$expected" || {
+            echo "bundle says $actual but package.json says $expected" >&2
+            exit 1
+          }
+
       - name: npm publish (harnesstrim)
         working-directory: packages/cli
         run: npm publish

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,11 +1,11 @@
 {
   "name": "harnesstrim",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "HarnessTrim CLI: doctor (diagnose token waste), install adapters, run benchmarks.",
   "license": "MIT",
   "type": "module",
   "bin": {
-    "harnesstrim": "./dist/cli.mjs"
+    "harnesstrim": "dist/cli.mjs"
   },
   "files": [
     "dist",

--- a/packages/cli/smoke-test.sh
+++ b/packages/cli/smoke-test.sh
@@ -29,6 +29,21 @@ TARBALL="$(ls "$WORK"/*.tgz 2>/dev/null | head -1)"
 [ -n "$TARBALL" ] || { echo "FAIL: npm pack produced no tarball"; exit 1; }
 echo "== smoke: packed $(basename "$TARBALL") =="
 
+# npm 11 performs an additional publish-time package.json normalization that
+# `npm pack` alone does not fully expose. v0.2.0 proved why this is a release
+# gate: "./dist/cli.mjs" packed and installed in this smoke test, but `npm publish`
+# stripped the bin mapping and shipped a package with no global command.
+PUBLISH_STDOUT="$WORK/publish-dry-run.json"
+PUBLISH_STDERR="$WORK/publish-dry-run.stderr"
+npm publish --dry-run --json >"$PUBLISH_STDOUT" 2>"$PUBLISH_STDERR" || {
+  cat "$PUBLISH_STDERR" >&2
+  fail "npm publish --dry-run failed"
+}
+if grep -Eq 'bin\[harnesstrim\].*(invalid|removed)|script name .* was invalid and removed' "$PUBLISH_STDERR"; then
+  cat "$PUBLISH_STDERR" >&2
+  fail "npm publish normalization would remove the harnesstrim bin"
+fi
+
 # 2. Install it into a fresh consumer project (zero transitive deps expected).
 PROJ="$WORK/consumer"
 mkdir -p "$PROJ"
@@ -45,7 +60,8 @@ fail() { echo "FAIL: $1"; exit 1; }
 
 # 3. --version prints a semver.
 V="$("$BIN" --version 2>&1)" || fail "--version exited non-zero ($V)"
-echo "$V" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+' || fail "--version did not print semver (got: $V)"
+EXPECTED_VERSION="$(node -p "require('$PKG_DIR/package.json').version")"
+[ "$V" = "$EXPECTED_VERSION" ] || fail "--version $V does not match package.json $EXPECTED_VERSION"
 echo "== smoke: --version -> $V =="
 
 # 4. doctor on a fresh dir (no crash, reports inspect).


### PR DESCRIPTION
Fixes the broken npm CLI publication in v0.2.0.

Root cause: npm 11 strips `bin` targets that start with `./` during publish-time normalization. The v0.2.0 workflow log explicitly warned that `bin[harnesstrim]` was removed, so `npm install -g harnesstrim@0.2.0` installed the package but created no new global command; an older 0.1.0 executable could remain visible on PATH.

Changes:
- bump to 0.2.1;
- change the bin target to `dist/cli.mjs`;
- make the smoke test fail if npm publish normalization would strip the CLI;
- require installed/bundled `--version` to exactly match package.json;
- add the same publish-time guard to the actual release job.