### PR TITLE
feat: trim GitHub Actions CI boilerplate safely

### DIFF
--- a/benchmarks/fixtures/ci/github-actions-log.txt
+++ b/benchmarks/fixtures/ci/github-actions-log.txt
@@ -1,0 +1,54 @@
+##[group]Run actions/checkout@v4
+Syncing repository: giuliastro/HarnessTrim
+Getting Git version info
+Temporarily overriding HOME=/home/runner/work/_temp/9d69 before making global git config changes
+Adding repository directory to the temporary git global config as a safe directory
+/usr/bin/git config --global --add safe.directory /home/runner/work/HarnessTrim/HarnessTrim
+Disabling automatic garbage collection
+Setting up auth
+Fetching the repository
+Determining the checkout info
+Checking out the ref
+##[endgroup]
+##[group]Run pnpm install --frozen-lockfile
+##[debug]Evaluating condition for step: install
+##[debug]Starting: install
+##[debug]Loading inputs
+##[debug]Loading env
+##[debug]Starting process
+##[debug]Process started with process id 2189
+##[debug]Waiting for process exit
+##[debug]Process exited with code 0
+Lockfile is up to date, resolution step is skipped
+Packages: +412
+Done in 6.8s
+##[endgroup]
+##[group]Run pnpm test
+##[debug]Evaluating condition for step: test
+##[debug]Starting: test
+##[debug]Loading inputs
+##[debug]Loading env
+##[debug]Starting process
+##[debug]Process started with process id 2240
+FAIL packages/core/src/example.test.ts
+  reducer safety
+    ✕ preserves the failing signal (12 ms)
+
+  ● reducer safety › preserves the failing signal
+
+    AssertionError: expected signal to survive
+      at packages/core/src/example.test.ts:42:12
+
+Tests:       1 failed, 47 passed, 48 total
+##[debug]Process exited with code 1
+##[debug]Finishing: test
+Error: Process completed with exit code 1.
+##[endgroup]
+##[group]Post Run actions/checkout@v4
+Post job cleanup.
+##[debug]Getting repository cleanup state
+##[debug]Removing auth header
+##[debug]Restoring HOME
+Cleaning up orphan processes
+warning: cache restore was skipped because the test step failed
+##[endgroup]

--- a/benchmarks/src/run.ts
+++ b/benchmarks/src/run.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { performance } from "node:perf_hooks";
 import {
+  ciLogSlim,
   fileListingSlim,
   genericTextSlim,
   gitDiffSlim,
@@ -95,6 +96,18 @@ const FIXTURES: Fixture[] = [
       "20 files checked, 10 had style suggestions",
       "no-console ×10", // which rules fired, aggregated
       "Run eslint --fix to apply automatic fixes.", // the actionable next step
+    ],
+  },
+  {
+    file: "ci/github-actions-log.txt",
+    reducer: ciLogSlim,
+    mustKeep: [
+      "##[group]Run pnpm test", // step identity
+      "FAIL packages/core/src/example.test.ts", // failing suite
+      "AssertionError: expected signal to survive", // failure reason
+      "Tests:       1 failed, 47 passed, 48 total", // test summary
+      "Error: Process completed with exit code 1.", // runner-level failure
+      "warning: cache restore was skipped because the test step failed", // warning signal
     ],
   },
 ];

--- a/packages/core/src/dispatch.test.ts
+++ b/packages/core/src/dispatch.test.ts
@@ -10,12 +10,36 @@ const bigGitDiff =
 const bigTestOutput =
   "PASS a\n".repeat(20) + "Tests:       1 failed, 19 passed, 20 total\n" + "y".repeat(DEFAULT_MIN_LENGTH);
 
+const bigCiLog =
+  "##[group]Run actions/checkout@v4\n" +
+  [
+    "Syncing repository: giuliastro/HarnessTrim",
+    "Getting Git version info",
+    "Temporarily overriding HOME=/home/runner/work/_temp/abc before making global git config changes",
+    "Adding repository directory to the temporary git global config as a safe directory",
+    "/usr/bin/git config --global --add safe.directory /home/runner/work/HarnessTrim/HarnessTrim",
+    "Disabling automatic garbage collection",
+    "Setting up auth",
+    "Fetching the repository",
+    "Determining the checkout info",
+    "Checking out the ref",
+  ].join("\n") +
+  "\n##[endgroup]\nFAIL src/example.test.ts\nTests:       1 failed, 19 passed, 20 total\n";
+
 test("pickReducer: detects git diff", () => {
   assert.equal(pickReducer(bigGitDiff)?.name, "git-diff-slim");
 });
 
 test("pickReducer: detects test output", () => {
   assert.equal(pickReducer(bigTestOutput)?.name, "test-output-slim");
+});
+
+test("pickReducer: detects full CI logs before embedded test output", () => {
+  assert.ok(bigCiLog.length >= 400, `expected length >= 400, got ${bigCiLog.length}`);
+  assert.equal(pickReducer(bigCiLog)?.name, "ci-log-slim");
+  const result = reduceAuto(bigCiLog);
+  assert.equal(result.reducer, "ci-log-slim");
+  assert.match(result.output, /FAIL src\/example\.test\.ts/);
 });
 
 test("pickReducer: detects long-form text", () => {

--- a/packages/core/src/dispatch.ts
+++ b/packages/core/src/dispatch.ts
@@ -6,6 +6,7 @@ import { jsonOutputSlim } from "./reducers/json-output-slim.ts";
 import { fileListingSlim } from "./reducers/file-listing-slim.ts";
 import { cronOutputSlim } from "./reducers/cron-output-slim.ts";
 import { lintOutputSlim } from "./reducers/lint-output-slim.ts";
+import { ciLogSlim } from "./reducers/ci-log-slim.ts";
 
 /** Below this length, reducing isn't worth it and risks churning small, stable content. */
 export const DEFAULT_MIN_LENGTH = 400;
@@ -18,6 +19,9 @@ const JSON_RE = /^\s*[\[{]/m;
 // File listing: ls permissions, find ./path, real tree branches, or search_files output
 const FILE_LISTING_RE = /(?:^total\s+\d+|^[\-bcdlsp][\-r][\-w][\-xs\-][\-r][\-w][\-xs\-][\-r][\-w][\-xs\-]|^\.\/(?:\.|[^.\s])|^\s*(?:├──|└──|│\s+)|^[\w.\/\-]+\.[a-zA-Z]{1,4}:\d+\|)/m;
 const CRON_OUTPUT_RE = /^# Cron Job:.*\n[\s\S]*^## Prompt\s*$[\s\S]*^## Response\s*$/m;
+// GitHub Actions / `gh run view --log` markers. The reducer itself only removes known-benign
+// setup/debug lines and preserves failures, warnings and exit codes.
+const CI_LOG_RE = /##\[(?:debug|group|endgroup)\]|(?:^|\t)(?:Syncing repository:|Post job cleanup\.)/m;
 // Lint-warning wall: repeated `path:line:col severity rule ...` lines (eslint/tsc/pylint style).
 const LINT_OUTPUT_RE = /^[\w.\/\\-]+:\d+:\d+\s+(?:warning|error)\s+[\w@.\/-]+\s/m;
 // Long-form text: has long prose paragraphs (lines of text without structural markers).
@@ -32,6 +36,9 @@ const LONG_TEXT_RE = /^#{1,4}\s.*\n(?:(?!^#{1,4}\s|^diff --git |^```).*\n){5,}/m
  */
 export function pickReducer(text: string): Reducer | null {
   if (GIT_DIFF_RE.test(text)) return gitDiffSlim;
+  // A full CI transcript may contain test FAIL/PASS lines; select the CI reducer first because it
+  // trims only surrounding runner boilerplate and leaves the embedded test signal untouched.
+  if (CI_LOG_RE.test(text) && text.length >= 400) return ciLogSlim;
   if (TEST_OUTPUT_RE.test(text)) return testOutputSlim;
   // A Hermes cron archive embeds arbitrary prompts/skills, so identify it before
   // inspecting JSON or listing-looking lines inside that archival prompt.

--- a/packages/core/src/reducers/ci-log-slim.test.ts
+++ b/packages/core/src/reducers/ci-log-slim.test.ts
@@ -1,0 +1,77 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ciLogSlim } from "./ci-log-slim.ts";
+
+const setupNoise = [
+  "Syncing repository: giuliastro/HarnessTrim",
+  "Getting Git version info",
+  "Temporarily overriding HOME=/home/runner/work/_temp/abc before making global git config changes",
+  "Adding repository directory to the temporary git global config as a safe directory",
+  "/usr/bin/git config --global --add safe.directory /home/runner/work/HarnessTrim/HarnessTrim",
+  "Disabling automatic garbage collection",
+  "Setting up auth",
+  "Fetching the repository",
+  "Determining the checkout info",
+  "Checking out the ref",
+].join("\n");
+
+test("ciLogSlim collapses known-benign checkout boilerplate", () => {
+  const input = `##[group]Run actions/checkout@v4\n${setupNoise}\n##[endgroup]\nRun pnpm test`;
+  const result = ciLogSlim.reduce(input);
+
+  assert.equal(result.changed, true);
+  assert.match(result.output, /\[harnesstrim:ci-log-slim\] omitted 10 CI setup\/debug line\(s\)/);
+  assert.match(result.output, /##\[group\]Run actions\/checkout@v4/);
+  assert.match(result.output, /Run pnpm test/);
+  assert.doesNotMatch(result.output, /Temporarily overriding HOME=/);
+});
+
+test("ciLogSlim preserves errors warnings failures and exit codes", () => {
+  const input = [
+    "##[debug]Evaluating condition for step: test",
+    "##[debug]Starting: test",
+    "##[debug]Loading inputs",
+    "error: package build failed",
+    "warning: cache restore was skipped",
+    "FAIL src/example.test.ts",
+    "Process completed with exit code 1.",
+  ].join("\n");
+  const result = ciLogSlim.reduce(input);
+
+  assert.equal(result.changed, true);
+  assert.match(result.output, /error: package build failed/);
+  assert.match(result.output, /warning: cache restore was skipped/);
+  assert.match(result.output, /FAIL src\/example\.test\.ts/);
+  assert.match(result.output, /Process completed with exit code 1\./);
+});
+
+test("ciLogSlim understands gh run view tab prefixes", () => {
+  const prefix = "quality\tCheckout\t2026-09-04T06:00:00Z\t";
+  const input = [
+    `${prefix}##[debug]Starting checkout`,
+    `${prefix}##[debug]Loading inputs`,
+    `${prefix}##[debug]Resolving repository`,
+    `${prefix}fatal: repository unavailable`,
+  ].join("\n");
+  const result = ciLogSlim.reduce(input);
+
+  assert.equal(result.changed, true);
+  assert.match(result.output, /omitted 3 CI setup\/debug line\(s\)/);
+  assert.match(result.output, /fatal: repository unavailable/);
+});
+
+test("ciLogSlim leaves short noise runs alone", () => {
+  const input = "##[debug]one\n##[debug]two\nRun pnpm test";
+  const result = ciLogSlim.reduce(input);
+  assert.equal(result.changed, false);
+  assert.equal(result.output, input);
+});
+
+test("ciLogSlim is idempotent", () => {
+  const input = `##[group]Run actions/checkout@v4\n${setupNoise}\n##[endgroup]`;
+  const once = ciLogSlim.reduce(input);
+  const twice = ciLogSlim.reduce(once.output);
+  assert.equal(once.changed, true);
+  assert.equal(twice.changed, false);
+  assert.equal(twice.output, once.output);
+});

--- a/packages/core/src/reducers/ci-log-slim.ts
+++ b/packages/core/src/reducers/ci-log-slim.ts
@@ -1,0 +1,81 @@
+import type { Reducer, ReducerResult } from "./types.ts";
+
+const MARKER_PREFIX = "[harnesstrim:ci-log-slim]";
+const MIN_NOISE_RUN = 3;
+
+const SIGNAL_RE = /\b(?:error|warning|warn|fail(?:ed|ure)?|fatal|exception|traceback)\b|exit code/i;
+
+const CI_NOISE_PATTERNS: readonly RegExp[] = [
+  /##\[debug\]/,
+  /^Syncing repository:/,
+  /^Getting Git version info$/,
+  /^Temporarily overriding HOME=/,
+  /^Adding repository directory to the temporary git global config as a safe directory$/,
+  /^Disabling automatic garbage collection$/,
+  /^Setting up auth$/,
+  /^Persisting credentials$/,
+  /^Fetching the repository$/,
+  /^Determining the checkout info$/,
+  /^Checking out the ref$/,
+  /^Post job cleanup\.$/,
+  /^Cleaning up orphan processes$/,
+  /^git version \d/i,
+  /^\/usr\/bin\/git config --global --add safe\.directory /,
+  /^\/usr\/bin\/git config --local --name-only --get-regexp /,
+];
+
+function stripGhRunPrefix(line: string): string {
+  // `gh run view --log` commonly prefixes lines with `<job>\t<step>\t<timestamp>`.
+  const parts = line.split("\t");
+  return parts.length >= 4 ? parts.slice(3).join("\t") : line;
+}
+
+function isNoiseLine(line: string): boolean {
+  if (line.startsWith(MARKER_PREFIX)) return false;
+  const payload = stripGhRunPrefix(line).trim();
+  if (!payload || SIGNAL_RE.test(payload)) return false;
+  return CI_NOISE_PATTERNS.some((pattern) => pattern.test(payload));
+}
+
+/**
+ * Collapses only known-benign GitHub Actions / `gh run view --log` boilerplate runs.
+ * Error, warning, failure and exit-code lines are never classified as noise. Short runs stay
+ * untouched so a few setup lines do not get replaced by a marker larger than the input.
+ *
+ * The reducer is deterministic and idempotent: its own marker is never treated as noise.
+ */
+export const ciLogSlim: Reducer = {
+  name: "ci-log-slim",
+  reduce(input: string): ReducerResult {
+    const lines = input.split(/\r?\n/);
+    const out: string[] = [];
+    let dropped = 0;
+
+    let index = 0;
+    while (index < lines.length) {
+      if (!isNoiseLine(lines[index])) {
+        out.push(lines[index]);
+        index += 1;
+        continue;
+      }
+
+      let end = index;
+      while (end < lines.length && isNoiseLine(lines[end])) end += 1;
+      const runLength = end - index;
+
+      if (runLength >= MIN_NOISE_RUN) {
+        out.push(`${MARKER_PREFIX} omitted ${runLength} CI setup/debug line(s)`);
+        dropped += runLength;
+      } else {
+        for (let cursor = index; cursor < end; cursor += 1) out.push(lines[cursor]);
+      }
+      index = end;
+    }
+
+    return {
+      output: out.join("\n"),
+      changed: dropped > 0,
+      note: dropped > 0 ? `dropped ${dropped} CI setup/debug line(s)` : undefined,
+    };
+  },
+};

--- a/packages/core/src/reducers/index.ts
+++ b/packages/core/src/reducers/index.ts
@@ -6,3 +6,4 @@ export { jsonOutputSlim } from "./json-output-slim.ts";
 export { fileListingSlim } from "./file-listing-slim.ts";
 export { cronOutputSlim } from "./cron-output-slim.ts";
 export { lintOutputSlim } from "./lint-output-slim.ts";
+export { ciLogSlim } from "./ci-log-slim.ts";


### PR DESCRIPTION
Adds a conservative `ci-log-slim` reducer for noisy GitHub Actions / `gh run view --log` transcripts.

Key properties:
- collapses only known-benign checkout/debug/setup runs;
- preserves error, warning, failure, fatal and exit-code lines by construction;
- routes full CI transcripts before embedded test output so test failures remain untouched while runner boilerplate is reduced;
- supports tab-prefixed `gh run view --log` output;
- deterministic, idempotent and fail-open through the existing dispatcher safety net;
- adds a Tier A fixture with must-keep CI/test failure signals so recall, idempotency, determinism and p95 latency remain release gates.

This follows the CI-log opportunity already recorded from dogfooding rather than adding a reducer without observed demand.