### PR TITLE
feat: slim noisy pnpm install progress

### DIFF
--- a/benchmarks/fixtures/package-manager/pnpm-install.txt
+++ b/benchmarks/fixtures/package-manager/pnpm-install.txt
@@ -1,0 +1,31 @@
+Scope: all 6 workspace projects
+Lockfile is up to date, resolution step is skipped
+Progress: resolved 1, reused 0, downloaded 0, added 0
+Progress: resolved 8, reused 6, downloaded 2, added 4
+Progress: resolved 17, reused 13, downloaded 4, added 11
+Progress: resolved 29, reused 24, downloaded 5, added 20
+Progress: resolved 41, reused 35, downloaded 6, added 31
+Packages: +125
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Progress: resolved 54, reused 48, downloaded 6, added 43
+Progress: resolved 67, reused 61, downloaded 6, added 56
+WARN deprecated inflight@1.0.6: This module is not supported and leaks memory
+Progress: resolved 79, reused 73, downloaded 6, added 68
+Progress: resolved 91, reused 85, downloaded 6, added 80
+Progress: resolved 102, reused 96, downloaded 6, added 91
+Progress: resolved 111, reused 105, downloaded 6, added 102
+Progress: resolved 118, reused 112, downloaded 6, added 111
+Progress: resolved 122, reused 116, downloaded 6, added 118
+Progress: resolved 125, reused 119, downloaded 6, added 122
+Progress: resolved 125, reused 119, downloaded 6, added 124
+Progress: resolved 125, reused 119, downloaded 6, added 125, done
+
+devDependencies:
++ @eslint/js 9.39.1
++ @types/node 24.7.0
++ eslint 9.39.1
++ prettier 3.6.2
++ typescript 5.9.3
++ vitest 3.2.4
+
+Done in 1.8s using pnpm v10.33.4

--- a/benchmarks/src/run.ts
+++ b/benchmarks/src/run.ts
@@ -9,6 +9,7 @@ import {
   gitDiffSlim,
   jsonOutputSlim,
   lintOutputSlim,
+  packageManagerOutputSlim,
   testOutputSlim,
   type Reducer,
 } from "@harnesstrim/core";
@@ -108,6 +109,17 @@ const FIXTURES: Fixture[] = [
       "Tests:       1 failed, 47 passed, 48 total", // test summary
       "Error: Process completed with exit code 1.", // runner-level failure
       "warning: cache restore was skipped because the test step failed", // warning signal
+    ],
+  },
+  {
+    file: "package-manager/pnpm-install.txt",
+    reducer: packageManagerOutputSlim,
+    mustKeep: [
+      "Packages: +125", // package-count summary
+      "WARN deprecated inflight@1.0.6", // warning signal
+      "Progress: resolved 125, reused 119, downloaded 6, added 125, done", // final state
+      "+ typescript 5.9.3", // installed-package identity
+      "Done in 1.8s using pnpm v10.33.4", // completion/timing
     ],
   },
 ];

--- a/packages/core/src/dispatch.ts
+++ b/packages/core/src/dispatch.ts
@@ -7,6 +7,7 @@ import { fileListingSlim } from "./reducers/file-listing-slim.ts";
 import { cronOutputSlim } from "./reducers/cron-output-slim.ts";
 import { lintOutputSlim } from "./reducers/lint-output-slim.ts";
 import { ciLogSlim } from "./reducers/ci-log-slim.ts";
+import { packageManagerOutputSlim } from "./reducers/package-manager-output-slim.ts";
 
 /** Below this length, reducing isn't worth it and risks churning small, stable content. */
 export const DEFAULT_MIN_LENGTH = 400;
@@ -24,6 +25,9 @@ const CRON_OUTPUT_RE = /^# Cron Job:.*\n[\s\S]*^## Prompt\s*$[\s\S]*^## Response
 const CI_LOG_RE = /##\[(?:debug|group|endgroup)\]|(?:^|\t)(?:Syncing repository:|Post job cleanup\.)/m;
 // Lint-warning wall: repeated `path:line:col severity rule ...` lines (eslint/tsc/pylint style).
 const LINT_OUTPUT_RE = /^[\w.\/\\-]+:\d+:\d+\s+(?:warning|error)\s+[\w@.\/-]+\s/m;
+// pnpm install/update output. The reducer requires at least three exact progress snapshots before
+// changing anything, so one incidental matching line cannot trigger a rewrite.
+const PACKAGE_MANAGER_OUTPUT_RE = /^Progress:\s+resolved\s+\d+,\s+reused\s+\d+,\s+downloaded\s+\d+,\s+added\s+\d+(?:,\s+done)?\s*$/m;
 // Long-form text: has long prose paragraphs (lines of text without structural markers).
 // Used as lowest-priority catch-all for briefings, reports, feature ideas, etc.
 const LONG_TEXT_RE = /^#{1,4}\s.*\n(?:(?!^#{1,4}\s|^diff --git |^```).*\n){5,}/m;
@@ -44,6 +48,7 @@ export function pickReducer(text: string): Reducer | null {
   // inspecting JSON or listing-looking lines inside that archival prompt.
   if (CRON_OUTPUT_RE.test(text) && text.length >= 400) return cronOutputSlim;
   if (LINT_OUTPUT_RE.test(text) && text.length >= 400) return lintOutputSlim;
+  if (PACKAGE_MANAGER_OUTPUT_RE.test(text) && text.length >= 400) return packageManagerOutputSlim;
   if (JSON_RE.test(text) && text.length >= 400) return jsonOutputSlim;
   if (FILE_LISTING_RE.test(text) && text.length >= 400) return fileListingSlim;
   if (LONG_TEXT_RE.test(text) && text.length >= 1000) return genericTextSlim;

--- a/packages/core/src/package-manager-dispatch.test.ts
+++ b/packages/core/src/package-manager-dispatch.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { pickReducer, reduceAuto } from "./dispatch.ts";
+
+function pnpmWall(): string {
+  const progress = Array.from(
+    { length: 12 },
+    (_, index) =>
+      `Progress: resolved ${index + 1}, reused ${index}, downloaded 0, added ${index}`,
+  ).join("\n");
+  return `Scope: all 6 workspace projects\n${progress}\nPackages: +125\nWARN deprecated sample@1.0.0\nProgress: resolved 125, reused 125, downloaded 0, added 125, done\nDone in 1.2s`;
+}
+
+describe("package-manager dispatch", () => {
+  it("selects the pnpm reducer for a noisy progress wall", () => {
+    const input = pnpmWall();
+    expect(input.length).toBeGreaterThan(400);
+    expect(pickReducer(input)?.name).toBe("package-manager-output-slim");
+
+    const result = reduceAuto(input);
+    expect(result.reducer).toBe("package-manager-output-slim");
+    expect(result.changed).toBe(true);
+    expect(result.output).toContain("WARN deprecated sample@1.0.0");
+    expect(result.output).toContain("Progress: resolved 125, reused 125, downloaded 0, added 125, done");
+  });
+
+  it("fails closed to no reduction when too few progress lines are present", () => {
+    const input = `${"context filler ".repeat(40)}\nProgress: resolved 1, reused 0, downloaded 0, added 0\nProgress: resolved 1, reused 1, downloaded 0, added 1, done`;
+    const result = reduceAuto(input);
+    expect(result.changed).toBe(false);
+    expect(result.reducer).toBeNull();
+    expect(result.output).toBe(input);
+  });
+});

--- a/packages/core/src/package-manager-dispatch.test.ts
+++ b/packages/core/src/package-manager-dispatch.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { test } from "node:test";
+import assert from "node:assert/strict";
 import { pickReducer, reduceAuto } from "./dispatch.ts";
 
 function pnpmWall(): string {
@@ -10,24 +11,25 @@ function pnpmWall(): string {
   return `Scope: all 6 workspace projects\n${progress}\nPackages: +125\nWARN deprecated sample@1.0.0\nProgress: resolved 125, reused 125, downloaded 0, added 125, done\nDone in 1.2s`;
 }
 
-describe("package-manager dispatch", () => {
-  it("selects the pnpm reducer for a noisy progress wall", () => {
-    const input = pnpmWall();
-    expect(input.length).toBeGreaterThan(400);
-    expect(pickReducer(input)?.name).toBe("package-manager-output-slim");
+test("package-manager dispatch selects the pnpm reducer for a noisy progress wall", () => {
+  const input = pnpmWall();
+  assert.ok(input.length > 400);
+  assert.equal(pickReducer(input)?.name, "package-manager-output-slim");
 
-    const result = reduceAuto(input);
-    expect(result.reducer).toBe("package-manager-output-slim");
-    expect(result.changed).toBe(true);
-    expect(result.output).toContain("WARN deprecated sample@1.0.0");
-    expect(result.output).toContain("Progress: resolved 125, reused 125, downloaded 0, added 125, done");
-  });
+  const result = reduceAuto(input);
+  assert.equal(result.reducer, "package-manager-output-slim");
+  assert.equal(result.changed, true);
+  assert.match(result.output, /WARN deprecated sample@1\.0\.0/);
+  assert.match(
+    result.output,
+    /Progress: resolved 125, reused 125, downloaded 0, added 125, done/,
+  );
+});
 
-  it("fails closed to no reduction when too few progress lines are present", () => {
-    const input = `${"context filler ".repeat(40)}\nProgress: resolved 1, reused 0, downloaded 0, added 0\nProgress: resolved 1, reused 1, downloaded 0, added 1, done`;
-    const result = reduceAuto(input);
-    expect(result.changed).toBe(false);
-    expect(result.reducer).toBeNull();
-    expect(result.output).toBe(input);
-  });
+test("package-manager dispatch fails closed when too few progress lines are present", () => {
+  const input = `${"context filler ".repeat(40)}\nProgress: resolved 1, reused 0, downloaded 0, added 0\nProgress: resolved 1, reused 1, downloaded 0, added 1, done`;
+  const result = reduceAuto(input);
+  assert.equal(result.changed, false);
+  assert.equal(result.reducer, null);
+  assert.equal(result.output, input);
 });

--- a/packages/core/src/reducers/index.ts
+++ b/packages/core/src/reducers/index.ts
@@ -7,3 +7,4 @@ export { fileListingSlim } from "./file-listing-slim.ts";
 export { cronOutputSlim } from "./cron-output-slim.ts";
 export { lintOutputSlim } from "./lint-output-slim.ts";
 export { ciLogSlim } from "./ci-log-slim.ts";
+export { packageManagerOutputSlim } from "./package-manager-output-slim.ts";

--- a/packages/core/src/reducers/package-manager-output-slim.test.ts
+++ b/packages/core/src/reducers/package-manager-output-slim.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { test } from "node:test";
+import assert from "node:assert/strict";
 import { packageManagerOutputSlim } from "./package-manager-output-slim.ts";
 
 const noisy = `Scope: all 6 workspace projects
@@ -17,46 +18,45 @@ devDependencies:
 
 Done in 1.8s using pnpm v10.33.4`;
 
-describe("packageManagerOutputSlim", () => {
-  it("collapses intermediate pnpm progress while preserving final state and signal", () => {
-    const result = packageManagerOutputSlim.reduce(noisy);
+test("packageManagerOutputSlim collapses intermediate pnpm progress while preserving signal", () => {
+  const result = packageManagerOutputSlim.reduce(noisy);
 
-    expect(result.changed).toBe(true);
-    expect(result.output).toContain("omitted 3 intermediate progress snapshot(s)");
-    expect(result.output).toContain("Packages: +125");
-    expect(result.output).toContain("WARN deprecated inflight@1.0.6");
-    expect(result.output).toContain(
-      "Progress: resolved 125, reused 120, downloaded 5, added 125, done",
-    );
-    expect(result.output).toContain("+ typescript 5.9.3");
-    expect(result.output).toContain("Done in 1.8s using pnpm v10.33.4");
-    expect(result.output).not.toContain("++++++++++++++++++++++++++++++++++++++++++++++++");
-    expect(result.output.length).toBeLessThan(noisy.length);
-  });
+  assert.equal(result.changed, true);
+  assert.match(result.output, /omitted 3 intermediate progress snapshot\(s\)/);
+  assert.match(result.output, /Packages: \+125/);
+  assert.match(result.output, /WARN deprecated inflight@1\.0\.6/);
+  assert.match(
+    result.output,
+    /Progress: resolved 125, reused 120, downloaded 5, added 125, done/,
+  );
+  assert.match(result.output, /\+ typescript 5\.9\.3/);
+  assert.match(result.output, /Done in 1\.8s using pnpm v10\.33\.4/);
+  assert.doesNotMatch(result.output, /\+{40,}/);
+  assert.ok(result.output.length < noisy.length);
+});
 
-  it("is idempotent", () => {
-    const first = packageManagerOutputSlim.reduce(noisy);
-    const second = packageManagerOutputSlim.reduce(first.output);
+test("packageManagerOutputSlim is idempotent", () => {
+  const first = packageManagerOutputSlim.reduce(noisy);
+  const second = packageManagerOutputSlim.reduce(first.output);
 
-    expect(second.changed).toBe(false);
-    expect(second.output).toBe(first.output);
-  });
+  assert.equal(second.changed, false);
+  assert.equal(second.output, first.output);
+});
 
-  it("leaves one or two progress snapshots untouched", () => {
-    const short = `Progress: resolved 1, reused 0, downloaded 0, added 0\nProgress: resolved 1, reused 1, downloaded 0, added 1, done`;
-    expect(packageManagerOutputSlim.reduce(short)).toEqual({ output: short, changed: false });
-  });
+test("packageManagerOutputSlim leaves one or two progress snapshots untouched", () => {
+  const short = `Progress: resolved 1, reused 0, downloaded 0, added 0\nProgress: resolved 1, reused 1, downloaded 0, added 1, done`;
+  assert.deepEqual(packageManagerOutputSlim.reduce(short), { output: short, changed: false });
+});
 
-  it("does not treat arbitrary progress text as pnpm output", () => {
-    const other = `Progress: indexing repository\nProgress: parsing AST\nProgress: writing report\n++++++++++++++++++++++++++++`;
-    expect(packageManagerOutputSlim.reduce(other)).toEqual({ output: other, changed: false });
-  });
+test("packageManagerOutputSlim does not treat arbitrary progress text as pnpm output", () => {
+  const other = `Progress: indexing repository\nProgress: parsing AST\nProgress: writing report\n++++++++++++++++++++++++++++`;
+  assert.deepEqual(packageManagerOutputSlim.reduce(other), { output: other, changed: false });
+});
 
-  it("preserves lifecycle errors byte-for-byte", () => {
-    const failing = `${noisy}\nERR_PNPM_RECURSIVE_RUN_FIRST_FAIL package failed\nELIFECYCLE Command failed with exit code 1`;
-    const result = packageManagerOutputSlim.reduce(failing);
+test("packageManagerOutputSlim preserves lifecycle errors byte-for-byte", () => {
+  const failing = `${noisy}\nERR_PNPM_RECURSIVE_RUN_FIRST_FAIL package failed\nELIFECYCLE Command failed with exit code 1`;
+  const result = packageManagerOutputSlim.reduce(failing);
 
-    expect(result.output).toContain("ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL package failed");
-    expect(result.output).toContain("ELIFECYCLE Command failed with exit code 1");
-  });
+  assert.match(result.output, /ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL package failed/);
+  assert.match(result.output, /ELIFECYCLE Command failed with exit code 1/);
 });

--- a/packages/core/src/reducers/package-manager-output-slim.test.ts
+++ b/packages/core/src/reducers/package-manager-output-slim.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { packageManagerOutputSlim } from "./package-manager-output-slim.ts";
+
+const noisy = `Scope: all 6 workspace projects
+Lockfile is up to date, resolution step is skipped
+Progress: resolved 1, reused 0, downloaded 0, added 0
+Packages: +125
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Progress: resolved 62, reused 60, downloaded 2, added 59
+WARN deprecated inflight@1.0.6: This module is not supported
+Progress: resolved 125, reused 120, downloaded 5, added 124
+Progress: resolved 125, reused 120, downloaded 5, added 125, done
+
+devDependencies:
++ prettier 3.6.2
++ typescript 5.9.3
+
+Done in 1.8s using pnpm v10.33.4`;
+
+describe("packageManagerOutputSlim", () => {
+  it("collapses intermediate pnpm progress while preserving final state and signal", () => {
+    const result = packageManagerOutputSlim.reduce(noisy);
+
+    expect(result.changed).toBe(true);
+    expect(result.output).toContain("omitted 3 intermediate progress snapshot(s)");
+    expect(result.output).toContain("Packages: +125");
+    expect(result.output).toContain("WARN deprecated inflight@1.0.6");
+    expect(result.output).toContain(
+      "Progress: resolved 125, reused 120, downloaded 5, added 125, done",
+    );
+    expect(result.output).toContain("+ typescript 5.9.3");
+    expect(result.output).toContain("Done in 1.8s using pnpm v10.33.4");
+    expect(result.output).not.toContain("++++++++++++++++++++++++++++++++++++++++++++++++");
+    expect(result.output.length).toBeLessThan(noisy.length);
+  });
+
+  it("is idempotent", () => {
+    const first = packageManagerOutputSlim.reduce(noisy);
+    const second = packageManagerOutputSlim.reduce(first.output);
+
+    expect(second.changed).toBe(false);
+    expect(second.output).toBe(first.output);
+  });
+
+  it("leaves one or two progress snapshots untouched", () => {
+    const short = `Progress: resolved 1, reused 0, downloaded 0, added 0\nProgress: resolved 1, reused 1, downloaded 0, added 1, done`;
+    expect(packageManagerOutputSlim.reduce(short)).toEqual({ output: short, changed: false });
+  });
+
+  it("does not treat arbitrary progress text as pnpm output", () => {
+    const other = `Progress: indexing repository\nProgress: parsing AST\nProgress: writing report\n++++++++++++++++++++++++++++`;
+    expect(packageManagerOutputSlim.reduce(other)).toEqual({ output: other, changed: false });
+  });
+
+  it("preserves lifecycle errors byte-for-byte", () => {
+    const failing = `${noisy}\nERR_PNPM_RECURSIVE_RUN_FIRST_FAIL package failed\nELIFECYCLE Command failed with exit code 1`;
+    const result = packageManagerOutputSlim.reduce(failing);
+
+    expect(result.output).toContain("ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL package failed");
+    expect(result.output).toContain("ELIFECYCLE Command failed with exit code 1");
+  });
+});

--- a/packages/core/src/reducers/package-manager-output-slim.ts
+++ b/packages/core/src/reducers/package-manager-output-slim.ts
@@ -1,0 +1,85 @@
+import type { Reducer, ReducerResult } from "./types.ts";
+
+const MARKER_PREFIX = "[harnesstrim:package-manager-output-slim]";
+const PNPM_PROGRESS_RE = /^Progress:\s+resolved\s+\d+,\s+reused\s+\d+,\s+downloaded\s+\d+,\s+added\s+\d+(?:,\s+done)?\s*$/;
+const DECORATION_RE = /^[+\-]{20,}\s*$/;
+
+function isProgress(line: string): boolean {
+  return PNPM_PROGRESS_RE.test(line);
+}
+
+function isDecoration(line: string): boolean {
+  return DECORATION_RE.test(line);
+}
+
+/**
+ * Collapse pnpm's repeated install progress snapshots while preserving the final snapshot and every
+ * semantic line around it (package counts, warnings, deprecations, lifecycle errors, timings, etc.).
+ *
+ * The reducer intentionally recognizes only pnpm's stable `Progress: resolved ..., reused ...,
+ * downloaded ..., added ...` shape. npm/yarn output is left untouched until separately fixture-proven.
+ */
+export const packageManagerOutputSlim: Reducer = {
+  name: "package-manager-output-slim",
+  reduce(input: string): ReducerResult {
+    if (input.includes(MARKER_PREFIX)) {
+      return { output: input, changed: false };
+    }
+
+    const lines = input.split(/\r?\n/);
+    const progressIndexes = lines
+      .map((line, index) => (isProgress(line) ? index : -1))
+      .filter((index) => index >= 0);
+
+    // A single progress snapshot is useful state, and two lines rarely repay a collapse marker.
+    if (progressIndexes.length < 3) {
+      return { output: input, changed: false };
+    }
+
+    const finalProgressIndex = progressIndexes[progressIndexes.length - 1];
+    const out: string[] = [];
+    let omittedProgress = 0;
+    let omittedDecoration = 0;
+    let markerWritten = false;
+
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+
+      if (isProgress(line) && index !== finalProgressIndex) {
+        omittedProgress += 1;
+        if (!markerWritten) {
+          out.push(MARKER_PREFIX);
+          markerWritten = true;
+        }
+        continue;
+      }
+
+      // pnpm prints long +/- bars beside package-count output. Only remove them after this blob has
+      // already qualified as a pnpm progress wall; standalone punctuation is never matched here.
+      if (isDecoration(line)) {
+        omittedDecoration += 1;
+        if (!markerWritten) {
+          out.push(MARKER_PREFIX);
+          markerWritten = true;
+        }
+        continue;
+      }
+
+      out.push(line);
+    }
+
+    if (!markerWritten) return { output: input, changed: false };
+
+    const markerIndex = out.indexOf(MARKER_PREFIX);
+    out[markerIndex] =
+      `${MARKER_PREFIX} omitted ${omittedProgress} intermediate progress snapshot(s)` +
+      (omittedDecoration > 0 ? ` and ${omittedDecoration} decorative line(s)` : "");
+
+    return {
+      output: out.join("\n"),
+      changed: true,
+      note: `dropped ${omittedProgress} pnpm progress snapshot(s)` +
+        (omittedDecoration > 0 ? ` and ${omittedDecoration} decorative line(s)` : ""),
+    };
+  },
+};


### PR DESCRIPTION
Adds a conservative `package-manager-output-slim` reducer for noisy pnpm install/update output.

The reducer only activates after at least three exact pnpm `Progress: resolved ..., reused ..., downloaded ..., added ...` snapshots are present. It removes intermediate progress snapshots and long +/- decoration while preserving the final progress state and all semantic lines around it, including package counts, installed package identities, warnings/deprecations, lifecycle errors, and completion timing.

Safety/quality:
- exact pnpm shape only; npm/yarn remain untouched until separately fixture-proven;
- one/two progress snapshots remain unchanged;
- deterministic and idempotent marker contract;
- dispatcher integration remains behind the existing 400-char threshold;
- unit tests cover signal preservation, idempotency, non-pnpm text, short progress output, and lifecycle failures;
- dispatcher tests cover positive routing and fail-open/no-change behavior;
- Tier A benchmark fixture measures token reduction, must-keep recall, determinism, idempotency, and p95 latency.

Measured Tier A result on the new fixture:
- pnpm install: **420 → 173 tokens (-58.8%)**
- must-keep signal: **5/5 (100%)**
- deterministic: yes
- idempotent: yes
- p95 reducer latency on Ubuntu CI: **0.025 ms**

Measured full Tier A suite after adding the fixture:
- **6081 → 1674 tokens (-72.5%)** across 9 fixtures
- **40/40 must-keep lines preserved (100% recall)**
- 0 dropped signal-looking lines
- determinism/idempotency/latency gates all pass; max fixture p95 0.159 ms against a 25 ms budget.

This continues HarnessTrim as the deterministic tool-output reduction layer; it does not duplicate Token Harness quota scheduling.