### PR TITLE
fix(ci): stop masking publish-normalization smoke failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: CLI build
         run: node packages/cli/build.mjs
       - name: Clean-package smoke test (npm pack -> fresh install)
-        run: bash packages/cli/smoke-test.sh
+        run: bash packages/cli/smoke-test-gate.sh
 
   hermes-plugin:
     name: hermes python plugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: CLI build
         run: node packages/cli/build.mjs
       - name: Clean-package smoke test (npm pack -> fresh install)
-        run: bash packages/cli/smoke-test.sh
+        run: bash packages/cli/smoke-test-gate.sh
 
   publish:
     name: publish

--- a/packages/cli/smoke-test-gate.sh
+++ b/packages/cli/smoke-test-gate.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# CI/release wrapper for smoke-test.sh.
+#
+# smoke-test.sh intentionally runs `npm publish --dry-run` to exercise npm 11's publish-time
+# package.json normalization. On ordinary PRs the package version is often already published, so
+# npm exits non-zero with the expected duplicate-version error *after* running that normalization.
+# The historical script called fail() before defining it, accidentally masking every publish
+# dry-run failure. This wrapper makes that first failure path explicit without changing the later
+# smoke assertions: only the known duplicate-version result is tolerated; every other error fails.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+fail() {
+  local message="${1:-smoke test failed}"
+  if [ "$message" = "npm publish --dry-run failed" ] &&
+     [ -n "${PUBLISH_STDERR:-}" ] &&
+     grep -Eqi 'cannot publish over (the )?previously published versions' "$PUBLISH_STDERR"; then
+    echo "== smoke: npm publish dry-run reached normalization; duplicate published version is expected =="
+    return 0
+  fi
+
+  if [ -n "${PUBLISH_STDERR:-}" ] && [ -f "$PUBLISH_STDERR" ]; then
+    cat "$PUBLISH_STDERR" >&2
+  fi
+  echo "FAIL: $message" >&2
+  exit 1
+}
+
+# Source rather than spawn: the early publish block sees the wrapper's fail(). smoke-test.sh later
+# defines its normal fail() for all remaining assertions, so only the historically broken call site
+# receives this duplicate-version exception handling.
+# shellcheck source=smoke-test.sh
+source "$SCRIPT_DIR/smoke-test.sh" "$@"


### PR DESCRIPTION
Fixes a real false-green path in the clean-package release gate.

`packages/cli/smoke-test.sh` calls `fail()` inside its initial `npm publish --dry-run` block before defining `fail()`. On the published 0.2.1 version npm correctly exits non-zero with “cannot publish over previously published versions”; the undefined function then produced `fail: command not found` and the smoke continued. That also meant a genuinely unexpected publish-normalization failure could be masked.

This PR adds a small `smoke-test-gate.sh` wrapper and routes both PR CI and release quality through it:
- the early `fail()` exists before the legacy smoke is sourced;
- only the known duplicate-published-version error is tolerated on ordinary PRs;
- every other `npm publish --dry-run` failure exits non-zero;
- publish-time warnings that would strip/normalize away the `harnesstrim` bin remain fatal in the existing smoke;
- once the initial publish block is past, `smoke-test.sh` defines its normal `fail()` and all later assertions behave unchanged;
- the release quality workflow uses the exact same gate as PR CI.

This does not weaken the publish job: a real new release version is still expected to pass its authenticated publish-time dry run normally.